### PR TITLE
fix: Intermittent crashes when scanning for files and programs

### DIFF
--- a/OpoLua/Model/Program.swift
+++ b/OpoLua/Model/Program.swift
@@ -123,7 +123,7 @@ class Program {
         self.url = url
         self.configuration = Configuration.load(for: url)
         self.thread = InterpreterThread(url: url)
-        let appInfo = Directory.appInfo(forApplicationUrl: url)
+        let appInfo = Directory.appInfo(forApplicationUrl: url, interpreter: OpoInterpreter())
         self.appInfo = appInfo
         self.title = appInfo?.caption ?? url.name
         self.icon = appInfo?.icon() ?? (url.pathExtension.lowercased() == "opo" ? .opo : .unknownApplication) // TODO: This should be an OPO icon if it's an OPO file.

--- a/OpoLua/Utilities/ProgramDetector.swift
+++ b/OpoLua/Utilities/ProgramDetector.swift
@@ -35,6 +35,7 @@ class ProgramDetector {
     private let updateQueue = DispatchQueue(label: "ProgramDetector.updateQueue")
     private var settingsSink: AnyCancellable?
     private var _items: [Directory.Item] = []
+    private var interpreter = OpoInterpreter()
 
     var items: [Directory.Item] {
         return _items
@@ -45,14 +46,14 @@ class ProgramDetector {
         self.settings = settings
     }
 
-    static func find(url: URL, filter: (Directory.Item) -> Bool) throws -> [Directory.Item] {
+    static func find(url: URL, filter: (Directory.Item) -> Bool, interpreter: OpoInterpreter) throws -> [Directory.Item] {
         var result: [Directory.Item] = []
-        for item in try Directory.items(for: url) {
+        for item in try Directory.items(for: url, interpreter: interpreter) {
             if filter(item) {
                 result.append(item)
             }
             if case Directory.Item.ItemType.directory = item.type {
-                result += try find(url: item.url, filter: filter)
+                result += try find(url: item.url, filter: filter, interpreter: interpreter)
             }
         }
         return result
@@ -70,7 +71,7 @@ class ProgramDetector {
                     default:
                         return false
                     }
-                })
+                }, interpreter: interpreter)
             }
             DispatchQueue.main.async {
                 self._items = items

--- a/OpoLua/View Controllers/Viewers/ImageViewController.swift
+++ b/OpoLua/View Controllers/Viewers/ImageViewController.swift
@@ -55,7 +55,7 @@ class ImageViewController: UITableViewController {
 
     init(url: URL) {
         self.url = url
-        let bitmaps = OpoInterpreter.shared.getMbmBitmaps(path: url.path) ?? []
+        let bitmaps = OpoInterpreter().getMbmBitmaps(path: url.path) ?? []
         self.images = bitmaps
             .compactMap { CGImage.from(bitmap: $0) }
             .compactMap { UIImage(cgImage: $0) }

--- a/swift/OpoInterpreter.swift
+++ b/swift/OpoInterpreter.swift
@@ -757,10 +757,6 @@ class OpoInterpreter {
 
     static let kOpTime: TimeInterval = 3.5 / 1000000 // Make this bigger to slow the interpreter down
 
-    static var shared: OpoInterpreter = {
-        return OpoInterpreter()
-    }()
-
     private let L: LuaState
     var iohandler: OpoIoHandler
     var lastOpTime = Date()


### PR DESCRIPTION
I was incorrectly reusing our shared `OpoInterpreter` on multiple threads which would occasionally lead to a crash. To address this, this change removes the shared interpreter and creates a new instance for each scanner queue.