### PR TITLE
fix: Rename the library to 'Library' (instead of 'OPL')

### DIFF
--- a/OpoLua/View Controllers/LibraryViewController.swift
+++ b/OpoLua/View Controllers/LibraryViewController.swift
@@ -69,7 +69,7 @@ class LibraryViewController: UICollectionViewController {
         self.taskManager = taskManager
         self.detector = detector
         super.init(collectionViewLayout: UICollectionViewCompositionalLayout.list(using: UICollectionLayoutListConfiguration(appearance: .insetGrouped)))
-        title = "OPL"
+        title = "Library"
         navigationItem.rightBarButtonItem = addBarButtonItem
         navigationItem.leftBarButtonItem = aboutBarButtonItem
 


### PR DESCRIPTION
This was previously 'OPL' and it was confusing as it didn't really describe the purpose of the view.