### PR TITLE
fix: Unnecessary directory monitoring can lead to crashes

### DIFF
--- a/OpoLua.xcodeproj/project.pbxproj
+++ b/OpoLua.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D81C12A8279EF0C0000E70D0 /* AllProgramsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81C12A7279EF0C0000E70D0 /* AllProgramsViewController.swift */; };
 		D82639362783CAE500AB4086 /* TimerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82639352783CAE500AB4086 /* TimerRequest.swift */; };
 		D82A37B827A9B43F00D8F5F4 /* DirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82A37B727A9B43F00D8F5F4 /* DirectoryMonitor.swift */; };
+		D82D2FCC27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D2FCB27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift */; };
 		D84ADB162771D937001ABFB4 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84ADB152771D937001ABFB4 /* Device.swift */; };
 		D84ADB182771DAB9001ABFB4 /* NSNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84ADB172771DAB9001ABFB4 /* NSNotification.swift */; };
 		D8535A28277139AB00DFCE29 /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8535A27277139AB00DFCE29 /* Sound.swift */; };
@@ -271,6 +272,7 @@
 		D81C12A7279EF0C0000E70D0 /* AllProgramsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllProgramsViewController.swift; sourceTree = "<group>"; };
 		D82639352783CAE500AB4086 /* TimerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerRequest.swift; sourceTree = "<group>"; };
 		D82A37B727A9B43F00D8F5F4 /* DirectoryMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryMonitor.swift; sourceTree = "<group>"; };
+		D82D2FCB27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveDirectoryMonitor.swift; sourceTree = "<group>"; };
 		D84ADB152771D937001ABFB4 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		D84ADB172771DAB9001ABFB4 /* NSNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotification.swift; sourceTree = "<group>"; };
 		D8535A27277139AB00DFCE29 /* Sound.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
@@ -591,11 +593,12 @@
 		D8D95502279B52250049A3C3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				D82A37B727A9B43F00D8F5F4 /* DirectoryMonitor.swift */,
 				D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */,
 				D8D95503279B52370049A3C3 /* Localization.swift */,
 				D890B46627A8CA7B007A7A78 /* ManagedItem.swift */,
 				D8EE4D85279E4D2900F91150 /* ProgramDetector.swift */,
-				D82A37B727A9B43F00D8F5F4 /* DirectoryMonitor.swift */,
+				D82D2FCB27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1051,6 +1054,7 @@
 				D8BA0970275196CA00F4730D /* String.swift in Sources */,
 				D8F4835D278D3D31008AF80C /* PixelView.swift in Sources */,
 				D8FE60032757106300711717 /* SecureLocation.swift in Sources */,
+				D82D2FCC27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift in Sources */,
 				D8632832279C240600B63625 /* UID.swift in Sources */,
 				D8891353274C186E00794D55 /* Canvas.swift in Sources */,
 				D8891345274BF25D00794D55 /* SwitchTableViewCell.swift in Sources */,

--- a/OpoLua/Extensions/OpoInterpreter+UIKit.swift
+++ b/OpoLua/Extensions/OpoInterpreter+UIKit.swift
@@ -46,10 +46,12 @@ extension OpoInterpreter.AppInfo {
             }
         }
         guard let bitmap = bitmap else {
+            #if DEBUG
             print("Failed to find icon for '\(self.caption)'.")
             for icon in icons {
                 print("  bitmap = \(icon.bitmap.size), mask = \(icon.mask!.size)")
             }
+            #endif
             return nil
         }
         if let cgImg = bitmap.cgImage {

--- a/OpoLua/Utilities/RecursiveDirectoryMonitor.swift
+++ b/OpoLua/Utilities/RecursiveDirectoryMonitor.swift
@@ -1,0 +1,198 @@
+// Copyright (c) 2021-2022 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Combine
+import Foundation
+
+class RecursiveDirectoryMonitor {
+
+    fileprivate struct ObserverContext {
+
+        let id = UUID()
+        let url: URL
+        let handler: () -> Void
+
+    }
+
+    class CancellableObserver: Cancellable {
+
+        private weak var monitor: RecursiveDirectoryMonitor?
+        private var context: ObserverContext
+
+        var url: URL {
+            return context.url
+        }
+
+        fileprivate init(monitor: RecursiveDirectoryMonitor, context: ObserverContext) {
+            self.monitor = monitor
+            self.context = context
+        }
+
+        deinit {
+            cancel()
+        }
+
+        func cancel() {
+            monitor?.cancel(context)
+            monitor = nil
+        }
+
+    }
+
+    enum State {
+        case idle
+        case running
+    }
+
+    static var shared: RecursiveDirectoryMonitor = {
+        let monitor = RecursiveDirectoryMonitor(queue: DispatchQueue(label: "RecursiveDirectoryMonitor.shared.queue"))
+        monitor.start()
+        return monitor
+    }()
+
+    // Returns resolved symlinks.
+    private static func directories(for url: URL) -> [URL] {
+        var children: [URL] = []
+        var paths: [URL] = [url]
+        while let url = paths.popLast() {
+            let files = FileManager.default.enumerator(at: url.resolvingSymlinksInPath(),
+                                                       includingPropertiesForKeys: [.isDirectoryKey])
+            while let fileUrl = files?.nextObject() as? URL {
+                let resourceValues = try! fileUrl.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+                if resourceValues.isSymbolicLink! {
+                    let resolvedUrl = fileUrl.resolvingSymlinksInPath()
+                    if resolvedUrl.isDirectory {
+                        paths.insert(resolvedUrl, at: 0)
+                    }
+                    continue
+                }
+                guard resourceValues.isDirectory! else {
+                    continue
+                }
+                children.append(fileUrl)
+            }
+        }
+        return children
+    }
+
+    private let queue: DispatchQueue
+    private var state: State = .idle
+
+    private var monitors: [DirectoryMonitor] = []
+    private var observers: [ObserverContext] = []
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func start() {
+        queue.async { [weak self] in
+            self?.queue_start()
+        }
+    }
+
+    func observe(url: URL, handler: @escaping () -> Void) -> CancellableObserver {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        let context = ObserverContext(url: url, handler: handler)
+        queue.async {
+            self.queue_addObserver(context: context)
+        }
+        return CancellableObserver(monitor: self, context: context)
+    }
+
+    private func cancel(_ context: ObserverContext) {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        queue.sync {
+            self.queue_removeObserver(context: context)
+        }
+    }
+
+    private func queue_addObserver(context: ObserverContext) {
+        dispatchPrecondition(condition: .onQueue(queue))
+        observers.append(context)
+        print("observers = \(observers.count)")
+        queue_updateSubDirectoryMonitors()
+    }
+
+    private func queue_removeObserver(context: ObserverContext) {
+        dispatchPrecondition(condition: .onQueue(queue))
+        observers.removeAll { $0.id == context.id }
+        print("observers = \(observers.count)")
+        queue_updateSubDirectoryMonitors()
+    }
+
+    private func queue_start() {
+        dispatchPrecondition(condition: .onQueue(queue))
+        guard state == .idle else {
+            return
+        }
+        state = .running
+    }
+
+    private func queue_updateSubDirectoryMonitors() {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        // Get URLs of all our sub-directories.
+        var urls = Set<URL>()
+        for observer in observers {
+            urls.insert(observer.url.resolvingSymlinksInPath())
+            for url in Self.directories(for: observer.url) {
+                urls.insert(url)
+            }
+        }
+
+        // Remove the monitors for the existing URLs causing them to cancel.
+        monitors.removeAll { !urls.contains($0.url) }
+
+        // Filter the list of URLs to remove the ones we're already monitoring.
+        for monitor in monitors {
+            urls.remove(monitor.url)
+        }
+
+        // Create monitors for the new URLs.
+        for url in urls {
+            let monitor = DirectoryMonitor(url: url, queue: queue)
+            monitor.delegate = self
+            monitors.append(monitor)
+            monitor.start()
+        }
+    }
+
+}
+
+extension RecursiveDirectoryMonitor: DirectoryMonitorDelegate {
+
+    func directoryMonitor(_ directoryMonitor: DirectoryMonitor, contentsDidChangeForUrl url: URL) {
+        dispatchPrecondition(condition: .onQueue(queue))
+        guard state == .running else {
+            return
+        }
+        queue_updateSubDirectoryMonitors()
+        for observer in observers {
+            observer.handler()
+        }
+    }
+
+    func directoryMonitor(_ directoryMonitor: DirectoryMonitor, didFailWithError error: Error) {
+        dispatchPrecondition(condition: .onQueue(queue))
+        monitors.removeAll { $0.url == directoryMonitor.url }
+    }
+
+}


### PR DESCRIPTION
The current mechanism we're using to monitor for file system changes requires us monitor each and every directory in the tree, causing us to open a large number of file handles if users add large directories. This change mitigates the impact of that by introducing a shared monitoring mechanism to ensure that we never watch a directory more than once, even if there are multiple observers for that directory.

The unfortunate side effect of this approach is that we're no longer able to be discrimitate when notifying observers about changes specific to them; we have to inform them of all changes, even if they're outside of their directory tree. That's because if there's ever a symlink in the path (which there often is), we loose the ability to determine if a changed URL is below a given root.

Thankfully the performance trade-offs seem to be OK for the time being, but it's definitely something we should keep an eye on. If these do become an issue, one option would be to rate limit change notifications and, longer-term, hopefully we can find a lower-level API that can monitor a directory structure recursively without the same resource demands.