### PR TITLE
fix: Ensure programs from iCloud Drive automatically appear in 'All Programs'

### DIFF
--- a/OpoLua.xcodeproj/project.pbxproj
+++ b/OpoLua.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		D80D65AC279DDF6B0020F994 /* IconCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */; };
 		D80D65AE279DE0CE0020F994 /* RunningProgramsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AD279DE0CE0020F994 /* RunningProgramsViewController.swift */; };
 		D80D65B0279E31220020F994 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AF279E31220020F994 /* Configuration.swift */; };
+		D81B4A4927B5AA650051B092 /* IndexableLocationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B4A4827B5AA650051B092 /* IndexableLocationObserver.swift */; };
+		D81B4A4D27B5CF650051B092 /* UbiquitousDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B4A4C27B5CF650051B092 /* UbiquitousDownloader.swift */; };
 		D81B875C2790D52C00E71960 /* DrawableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B875B2790D52C00E71960 /* DrawableViewController.swift */; };
 		D81B875E2790DAAD00E71960 /* InstallerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B875D2790DAAD00E71960 /* InstallerViewController.swift */; };
 		D81B87612790ECC500E71960 /* InstallerIntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B87602790ECC500E71960 /* InstallerIntroductionViewController.swift */; };
@@ -274,6 +276,8 @@
 		D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconCollectionViewLayout.swift; sourceTree = "<group>"; };
 		D80D65AD279DE0CE0020F994 /* RunningProgramsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningProgramsViewController.swift; sourceTree = "<group>"; };
 		D80D65AF279E31220020F994 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		D81B4A4827B5AA650051B092 /* IndexableLocationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexableLocationObserver.swift; sourceTree = "<group>"; };
+		D81B4A4C27B5CF650051B092 /* UbiquitousDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UbiquitousDownloader.swift; sourceTree = "<group>"; };
 		D81B875B2790D52C00E71960 /* DrawableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawableViewController.swift; sourceTree = "<group>"; };
 		D81B875D2790DAAD00E71960 /* InstallerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerViewController.swift; sourceTree = "<group>"; };
 		D81B87602790ECC500E71960 /* InstallerIntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerIntroductionViewController.swift; sourceTree = "<group>"; };
@@ -619,9 +623,11 @@
 				D82A37B727A9B43F00D8F5F4 /* DirectoryMonitor.swift */,
 				D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */,
 				D8D95503279B52370049A3C3 /* Localization.swift */,
+				D81B4A4827B5AA650051B092 /* IndexableLocationObserver.swift */,
 				D890B46627A8CA7B007A7A78 /* ManagedItem.swift */,
 				D8EE4D85279E4D2900F91150 /* ProgramDetector.swift */,
 				D82D2FCB27AB4FBC001A4283 /* RecursiveDirectoryMonitor.swift */,
+				D81B4A4C27B5CF650051B092 /* UbiquitousDownloader.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1049,6 +1055,7 @@
 				D8BA096E2751960F00F4730D /* TextFieldTableViewCell.swift in Sources */,
 				D893EAD32760739500E64219 /* Border.swift in Sources */,
 				DB7900232746C771005E904F /* LuaState.swift in Sources */,
+				D81B4A4D27B5CF650051B092 /* UbiquitousDownloader.swift in Sources */,
 				D81B87612790ECC500E71960 /* InstallerIntroductionViewController.swift in Sources */,
 				DB0B914A276E1BC5006F5CD0 /* OplKeyCode.swift in Sources */,
 				DB79001D2746BC33005E904F /* OpoIoHandler.swift in Sources */,
@@ -1116,6 +1123,7 @@
 				DB79000B2742E6F6005E904F /* lobject.c in Sources */,
 				D8D50117275928CF008C1BC9 /* Scheduler.swift in Sources */,
 				D8C679BA27483B5600BD8720 /* DirectoryViewController.swift in Sources */,
+				D81B4A4927B5AA650051B092 /* IndexableLocationObserver.swift in Sources */,
 				DB6B438427A55D1200625788 /* RootView.swift in Sources */,
 				DB9533F927AB0D72001CF58D /* LuaDecoder.swift in Sources */,
 				D89A607A2756A2CC00C9757F /* FileManager.swift in Sources */,

--- a/OpoLua/AppDelegate.swift
+++ b/OpoLua/AppDelegate.swift
@@ -34,12 +34,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // N.B. We only ever store previous section for state restoration as we always want to restore to at least the top-level of the section.
 
     private var settings = Settings()
+
     private lazy var taskManager: TaskManager = {
         return TaskManager(settings: settings)
     }()
+
     private lazy var detector: ProgramDetector = {
         return ProgramDetector(settings: settings)
     }()
+
+    lazy var downloader: UbiquitousDownloader = {
+        return UbiquitousDownloader(settings: settings)
+    }()
+
     var splitViewController: UISplitViewController!
     var libraryViewController: LibraryViewController!
     var settingsSink: AnyCancellable?
@@ -77,6 +84,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         taskManager.delegate = self
 
         detector.start()
+        downloader.start()
 
         return true
     }

--- a/OpoLua/Model/Directory.swift
+++ b/OpoLua/Model/Directory.swift
@@ -216,7 +216,6 @@ class Directory {
 
     private func updateQueue_refresh() {
         dispatchPrecondition(condition: .onQueue(updateQueue))
-        FileManager.default.startDownloadingUbitquitousItemsRecursive(for: url)
         do {
             let items = try Self.items(for: url, interpreter: interpreter)
             DispatchQueue.main.async { [weak self] in

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -30,6 +30,8 @@ class Installer {
 
     typealias Result = Swift.Result<Directory.Item?, Error>
 
+    static let didCompleteInstall = NSNotification.Name(rawValue: "InstallerDidCompleteInstall")
+
     let url: URL
     let destinationUrl: URL
     let fileSystem: FileSystem
@@ -56,6 +58,9 @@ class Installer {
                     item = nil
                 }
                 self.delegate?.installer(self, didFinishWithResult: .success(item))
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: Installer.didCompleteInstall, object: self)
+                }
             } catch {
                 // TODO: Clean up if we've failed to install the file.
                 self.delegate?.installer(self, didFinishWithResult: .failure(error))

--- a/OpoLua/Utilities/IndexableLocationObserver.swift
+++ b/OpoLua/Utilities/IndexableLocationObserver.swift
@@ -1,0 +1,112 @@
+// Copyright (c) 2021-2022 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+// Called on IndexableLocationObserver.targetQueue
+protocol IndexableLocationObserverDelegate: AnyObject {
+
+    func indexableLocationObserver(_ indexableLocationObserver: IndexableLocationObserver,
+                                   didUpdateIndexableContents indexableContents: [URL])
+    func indexableLocationObserver(_ indexableLocationObserver: IndexableLocationObserver,
+                                   didFailWithError error: Error)
+
+    // TODO: Cancel handler.
+
+}
+
+class IndexableLocationObserver: NSObject {
+
+    private let settings: Settings
+    private let updateQueue = DispatchQueue(label: "UbiquitousFileDownloader.updateQueue",
+                                            attributes: .initiallyInactive)
+    private var observers: [RecursiveDirectoryMonitor.CancellableObserver] = []
+
+    weak var delegate: IndexableLocationObserverDelegate?
+
+    init(settings: Settings, targetQueue: DispatchQueue? = nil) {
+        self.settings = settings
+        super.init()
+        updateQueue.setTarget(queue: targetQueue)
+        updateQueue.activate()
+    }
+
+    private func observeIndexableUrl(_ indexableUrl: URL) {
+        let observer = RecursiveDirectoryMonitor.shared.observe(url: indexableUrl) { [weak self] in
+            DispatchQueue.main.async {
+                self?.update()
+            }
+        } errorHandler: { [weak self] error in
+            DispatchQueue.main.async {
+                self?.cancelWithError(error)
+            }
+        }
+        observers.append(observer)
+    }
+
+    func start() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        settings.addObserver(self)
+        for indexableUrl in settings.indexableUrls {
+            observeIndexableUrl(indexableUrl)
+        }
+        self.update()
+    }
+
+    func update() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let urls = settings.indexableUrls
+        updateQueue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.delegate?.indexableLocationObserver(self, didUpdateIndexableContents: urls)
+        }
+    }
+
+    func cancelWithError(_ error: Error) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        settings.removeObserver(self)
+        for observer in observers {
+            observer.cancel()
+        }
+        observers.removeAll()
+        updateQueue.async {
+            self.delegate?.indexableLocationObserver(self, didFailWithError: error)
+        }
+    }
+
+}
+
+extension IndexableLocationObserver: SettingsObserver {
+
+    func settings(_ settings: Settings, didAddIndexableUrl indexableUrl: URL) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        observeIndexableUrl(indexableUrl)
+        self.update()
+    }
+
+    func settings(_ settings: Settings, didRemoveIndexableUrl indexableUrl: URL) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        observers.removeAll { $0.url == indexableUrl }
+        self.update()
+    }
+
+}

--- a/OpoLua/Utilities/IndexableLocationObserver.swift
+++ b/OpoLua/Utilities/IndexableLocationObserver.swift
@@ -28,8 +28,6 @@ protocol IndexableLocationObserverDelegate: AnyObject {
     func indexableLocationObserver(_ indexableLocationObserver: IndexableLocationObserver,
                                    didFailWithError error: Error)
 
-    // TODO: Cancel handler.
-
 }
 
 class IndexableLocationObserver: NSObject {

--- a/OpoLua/Utilities/UbiquitousDownloader.swift
+++ b/OpoLua/Utilities/UbiquitousDownloader.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2021-2022 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+class UbiquitousDownloader {
+
+    private let settings: Settings
+    private let indexableLocationObserver: IndexableLocationObserver
+
+    init(settings: Settings) {
+        self.settings = settings
+        indexableLocationObserver = IndexableLocationObserver(settings: settings)
+        indexableLocationObserver.delegate = self
+    }
+
+    func start() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        indexableLocationObserver.start()
+    }
+
+    func update() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        for url in settings.indexableUrls {
+            FileManager.default.startDownloadingUbitquitousItemsRecursive(for: url)
+        }
+    }
+
+}
+
+extension UbiquitousDownloader: IndexableLocationObserverDelegate {
+
+    func indexableLocationObserver(_ indexableLocationObserver: IndexableLocationObserver,
+                                   didUpdateIndexableContents indexableContents: [URL]) {
+        DispatchQueue.main.async {
+            self.update()
+        }
+    }
+
+    func indexableLocationObserver(_ indexableLocationObserver: IndexableLocationObserver,
+                                   didFailWithError error: Error) {
+    }
+
+}

--- a/OpoLua/View Controllers/AllProgramsViewController.swift
+++ b/OpoLua/View Controllers/AllProgramsViewController.swift
@@ -153,6 +153,7 @@ class AllProgramsViewController : UICollectionViewController {
 
     @objc func refreshControlDidChange(_ sender: UIRefreshControl) {
         detector.update()
+        AppDelegate.shared.downloader.update()
     }
 
     func updateWallpaper() {

--- a/OpoLua/View Controllers/DirectoryViewController.swift
+++ b/OpoLua/View Controllers/DirectoryViewController.swift
@@ -44,6 +44,7 @@ class DirectoryViewController : UICollectionViewController {
     var directory: Directory
     private var installer: Installer?
     private var applicationActiveObserver: Any?
+    private var installerObserver: Any?
     private var settingsSink: AnyCancellable?
 
     override var canBecomeFirstResponder: Bool {
@@ -129,6 +130,14 @@ class DirectoryViewController : UICollectionViewController {
             }
             self.directory.refresh()
         }
+        installerObserver = notificationCenter.addObserver(forName: Installer.didCompleteInstall,
+                                                           object: nil,
+                                                           queue: nil) { [weak self] notification in
+            guard let self = self else {
+                return
+            }
+            self.directory.refresh()
+        }
         directory.start()
         settingsSink = settings.objectWillChange.sink { [weak self] _ in
             guard let self = self else {
@@ -165,6 +174,7 @@ class DirectoryViewController : UICollectionViewController {
 
     @objc func refreshControlDidChange(_ sender: UIRefreshControl) {
         directory.refresh()
+        AppDelegate.shared.downloader.update()
     }
 
     func updateWallpaper() {


### PR DESCRIPTION
This change includes a drive-by fix to use the notification center as a belt-and-braces approach to ensure 'All Programs' and the current directory are updated following a successful install.