### PR TITLE
fix: crash in iOS 16

### DIFF
--- a/OpoLua/Extensions/CGImage.swift
+++ b/OpoLua/Extensions/CGImage.swift
@@ -353,7 +353,7 @@ extension CGImage {
             return CGImage(width: bitmap.width, height: bitmap.height,
                 bitsPerComponent: 8, bitsPerPixel: 8,
                 bytesPerRow: stride, space: sp,
-                bitmapInfo: CGBitmapInfo.byteOrder32Little,
+                bitmapInfo: CGBitmapInfo.byteOrderDefault,
                 provider: provider, decode: nil, shouldInterpolate: false,
                 intent: .defaultIntent)!
         case .gray256:


### PR DESCRIPTION
Which apparently no longer lets you get away with byteOrder32Little in an 8bpp greyscale image.