### PR TITLE
fix: Crash when adding large directories

### DIFF
--- a/OpoLua/Utilities/RecursiveDirectoryMonitor.swift
+++ b/OpoLua/Utilities/RecursiveDirectoryMonitor.swift
@@ -96,7 +96,7 @@ class RecursiveDirectoryMonitor {
         case cancelled
     }
 
-    static let maximumDirectoryCount = 1000
+    static let maximumDirectoryCount = 20
 
     static var shared: RecursiveDirectoryMonitor = {
         let monitor = RecursiveDirectoryMonitor()


### PR DESCRIPTION
It looks like iOS 16 is far more agressive about limiting open file handles meaning we were running out of resources when monitoring large directory structures. This dials the number of open monitors down to 20 from 1000 and relies on manual refresh as a recovery mechanism. Hopefully we can find a better solution in the future.