### PR TITLE
ci: Revert to building on macOS Monterey

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     name: build
-    runs-on: macos-ventura
+    runs-on: macos-monterey
 
     steps:
 


### PR DESCRIPTION
Looks like builds don't work on Ventura right now; restoring to Monterey until other build issues have been resolved.