### PR TITLE
fix: Update about screen website link

### DIFF
--- a/OpoLua/View Controllers/SettingsView.swift
+++ b/OpoLua/View Controllers/SettingsView.swift
@@ -86,7 +86,7 @@ struct SettingsView: View {
                 case .about:
 
                     AboutView(repository: "inseven/opolua", copyright: "Copyright © 2021-2023\nJason Morley, Tom Sutcliffe") {
-                        Action("InSeven Limited", url: URL(string: "https://inseven.co.uk")!)
+                        Action("Website", url: URL(string: "https://opolua.org")!)
                         Action("Privacy Policy", url: URL(string: "https://opolua.org/privacy-policy")!)
                         Action("GitHub", url: URL(string: "https://github.com/inseven/opolua")!)
                         Action("Support", url: URL(address: "support@opolua.org", subject: "OpoLua Support")!)


### PR DESCRIPTION
This updates the website link to go to https://opolua.org instead of https://inseven.co.uk. This is preparatory work for migrating the app to a personal developer account.