### PR TITLE
fix: "Close Program" was not setting GETCMD=X correctly

### DIFF
--- a/src/opl.lua
+++ b/src/opl.lua
@@ -871,7 +871,7 @@ function GETEVENTA32(stat, evAddr)
         -- The GETCMD$ API is so stupid...
         if stat() == KErrNone then
             local ev = evAddr:asVariable(DataTypes.ELongArray)
-            if ev[KEvAType] == KEvCommand then
+            if ev[KEvAType]() == KEvCommand then
                 -- We never use KEvCommand for anything except quitCommand, so we can assume that here
                 runtime:setResource("GETCMD", "X")
             end


### PR DESCRIPTION
I think this got broken somewhere in the memory model refactor, either that or it's been broken ever since 6a4bc89...