### PR TITLE
fix: better menu scrollbar support

### DIFF
--- a/src/opl.lua
+++ b/src/opl.lua
@@ -136,8 +136,8 @@ end
 
 function gAT(x, y)
     local contextPos = runtime:getGraphicsContext().pos
-    contextPos.x = x
-    contextPos.y = y
+    contextPos.x = assert(x)
+    contextPos.y = assert(y)
 end
 
 function gMOVE(x, y)


### PR DESCRIPTION
In particular in MENU calls with menus that have dividing lines in as well as scrollbars, which necessitates supporting smooth scrolling as opposed to only scrolling in multiples of the line height.

Also fixes several graphical glitches in menus with scrollbars, such as submenu arrows not drawing in the correct location, performance, and flicker.