### PR TITLE
fix: dEDITMULTI, PEEK$ commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,14 @@ This interpreter is not 100% behaviour compatible with the original Psion. The m
 
 ## Example
 
-[simple.txt](examples/simple.txt) compiled on a Psion Series 5:
+[simple.txt](examples/Tests/simple.txt) compiled on a Psion Series 5:
 
 ```
-$ cd src
-$ ./runopo.lua ../examples/simple.opo
+$ ./src/runopo.lua --noget examples/Tests/simple.opo
 Hello world!
 Waaaat
-
-$ ./dumpopo.lua ../examples/simple.opo --all
+(Skipping get)
+$ ./src/dumpopo.lua examples/Tests/simple.opo --all
 Source name: D:\Program
 procTableIdx: 0x0000006B
 1: TEST @ 0x0000001F code=0x00000036 line=0

--- a/src/cmdline.lua
+++ b/src/cmdline.lua
@@ -23,7 +23,7 @@ SOFTWARE.
 ]]
 
 -- Use to bootstrap cmdline scripts with the following magic:
--- sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+-- dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 -- local args = getopt({ ... })
 
 local args = arg

--- a/src/compile.lua
+++ b/src/compile.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumpaif.lua
+++ b/src/dumpaif.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumpdfs.lua
+++ b/src/dumpdfs.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumpmbm.lua
+++ b/src/dumpmbm.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumpopo.lua
+++ b/src/dumpopo.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumprsc.lua
+++ b/src/dumprsc.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/fns.lua
+++ b/src/fns.lua
@@ -1210,7 +1210,9 @@ function NumStr(stack, runtime) -- 0xCE
 end
 
 function PeekStr(stack, runtime) -- 0xCF
-    unimplemented("fns.PeekStr")
+    local addr = runtime:addrFromInt(stack:pop())
+    local var = addr:asVariable(DataTypes.EString)
+    stack:push(var())
 end
 
 function ReptStr(stack, runtime) -- 0xD0

--- a/src/init.lua
+++ b/src/init.lua
@@ -232,7 +232,8 @@ dItemTypes = enum {
     dPOSITION = 11,
     dCHECKBOX = 12,
     -- simulated types, not actually used by OPL
-    dSEPARATOR = 13,
+    dSEPARATOR = 257,
+    dEDITMULTI = 258,
 }
 
 KDefaultFontUid = KFontArialNormal15

--- a/src/opltotext.lua
+++ b/src/opltotext.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({

--- a/src/ops.lua
+++ b/src/ops.lua
@@ -2631,7 +2631,19 @@ function gSetPenWidth(stack, runtime) -- 0x134
 end
 
 function dEditMulti(stack, runtime) -- 0x135
-    unimplemented("dEditMulti")
+    local dialog = runtime:getDialog()
+    local item = { type = dItemTypes.dEDITMULTI }
+    item.len = stack:pop()
+    item.numLines = stack:pop()
+    item.widthChars = stack:pop()
+    item.prompt = stack:pop()
+    item.addr = runtime:addrFromInt(stack:pop())
+
+    local len = string.unpack("<i4", item.addr:read(4))
+    local startOfData = item.addr + 4
+    item.value = startOfData:read(len)
+
+    table.insert(dialog.items, item)
 end
 
 function gXBorder32(stack, runtime) -- 0x13B

--- a/src/runopo.lua
+++ b/src/runopo.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 function main()
     local args = getopt({
@@ -67,7 +67,7 @@ function main()
 
     if args.noget then
         iohandler.getch = function()
-            print("Skipping get")
+            print("(Skipping get)")
             return 13 -- ie enter
         end
     end

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -566,8 +566,8 @@ function Runtime:drawCmd(type, op)
 end
 
 function Runtime:flushGraphicsOps()
-    local graphics = self:getGraphics()
-    if graphics.buffer and graphics.buffer[1] then
+    local graphics = self.graphics
+    if graphics and graphics.buffer and graphics.buffer[1] then
         self.ioh.draw(graphics.buffer)
         graphics.buffer = {}
     end

--- a/src/tcompiler.lua
+++ b/src/tcompiler.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env lua
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 local compiler = require("compiler")
 local opofile = require("opofile")

--- a/src/tmemory.lua
+++ b/src/tmemory.lua
@@ -24,7 +24,7 @@ SOFTWARE.
 
 ]]
 
-sep=package.config:sub(1,1);dofile(arg[0]:sub(1, arg[0]:match(sep.."?()[^"..sep.."]+$") - 1).."cmdline.lua")
+dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
 local EWord = DataTypes.EWord
 local ELong = DataTypes.ELong


### PR DESCRIPTION
Also:
* Limited support for rendering dEDITMULTI
* more compact boilerplate for cmdline scripts
* Calling GET() no longer forces root window to be created (desirable when using runopo.lua)