### PR TITLE
refactor: Enable `OpoInterpreter` reuse in other projects

### DIFF
--- a/OpoLua.xcodeproj/project.pbxproj
+++ b/OpoLua.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		D8C3BD652774BEC2003B1AD0 /* Console.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C3BD642774BEC2003B1AD0 /* Console.swift */; };
 		D8C3BD672774BF1F003B1AD0 /* OpoLuaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C3BD662774BF1F003B1AD0 /* OpoLuaError.swift */; };
 		D8C3BD6A2774F4A2003B1AD0 /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8C3BD692774F4A2003B1AD0 /* GameController.framework */; };
+		D8C409632C3CF62900C9E857 /* OpoIoHandler_UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C409622C3CF62900C9E857 /* OpoIoHandler_UIKit.swift */; };
+		D8C409862C3CF6DB00C9E857 /* CGImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C409852C3CF6DB00C9E857 /* CGImage.swift */; };
 		D8C43DF527C3EFEF00944A11 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C43DF427C3EFEF00944A11 /* RootViewController.swift */; };
 		D8C679BA27483B5600BD8720 /* DirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C679B927483B5600BD8720 /* DirectoryViewController.swift */; };
 		D8C679BD27484BF400BD8720 /* examples in Resources */ = {isa = PBXBuildFile; fileRef = D8C679BC27484BF400BD8720 /* examples */; };
@@ -103,7 +105,6 @@
 		D8FE60072757201600711717 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FE60062757201600711717 /* Bundle.swift */; };
 		D8FE60092757208000711717 /* ApplicationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FE60082757208000711717 /* ApplicationError.swift */; };
 		DB0B914A276E1BC5006F5CD0 /* OplKeyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0B9149276E1BC5006F5CD0 /* OplKeyCode.swift */; };
-		DB0B918227710120006F5CD0 /* CGImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0B918127710120006F5CD0 /* CGImage.swift */; };
 		DB0B91862771031F006F5CD0 /* sis.lua in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB0B91842771031F006F5CD0 /* sis.lua */; };
 		DB0B9191278369A4006F5CD0 /* BitmapFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0B9190278369A4006F5CD0 /* BitmapFont.swift */; };
 		DB0B919327836E70006F5CD0 /* fonts in Resources */ = {isa = PBXBuildFile; fileRef = DB0B919227836E70006F5CD0 /* fonts */; };
@@ -113,7 +114,7 @@
 		DB5AC970275198A20043FE5C /* database.lua in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB5AC96F275198A20043FE5C /* database.lua */; };
 		DB5AC972275577990043FE5C /* mbm.lua in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB5AC971275577980043FE5C /* mbm.lua */; };
 		DB5AC974275681510043FE5C /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5AC973275681510043FE5C /* CanvasView.swift */; };
-		DB5AC9762757B6ED0043FE5C /* OpoIoHandler_CGExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CGExtensions.swift */; };
+		DB5AC9762757B6ED0043FE5C /* OpoIoHandler_CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CoreGraphics.swift */; };
 		DB5AC97A275AC72A0043FE5C /* sound.lua in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB5AC979275AC72A0043FE5C /* sound.lua */; };
 		DB5AC97C275CD5690043FE5C /* opl.lua in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB5AC97B275CD5690043FE5C /* opl.lua */; };
 		DB6B438427A55D1200625788 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6B438327A55D1200625788 /* RootView.swift */; };
@@ -270,6 +271,8 @@
 		D8C3BD642774BEC2003B1AD0 /* Console.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Console.swift; sourceTree = "<group>"; };
 		D8C3BD662774BF1F003B1AD0 /* OpoLuaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpoLuaError.swift; sourceTree = "<group>"; };
 		D8C3BD692774F4A2003B1AD0 /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.2.sdk/System/Library/Frameworks/GameController.framework; sourceTree = DEVELOPER_DIR; };
+		D8C409622C3CF62900C9E857 /* OpoIoHandler_UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpoIoHandler_UIKit.swift; sourceTree = "<group>"; };
+		D8C409852C3CF6DB00C9E857 /* CGImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGImage.swift; sourceTree = "<group>"; };
 		D8C43DF427C3EFEF00944A11 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
 		D8C679B927483B5600BD8720 /* DirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryViewController.swift; sourceTree = "<group>"; };
 		D8C679BC27484BF400BD8720 /* examples */ = {isa = PBXFileReference; lastKnownFileType = folder; path = examples; sourceTree = "<group>"; };
@@ -297,7 +300,6 @@
 		D8FE60062757201600711717 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		D8FE60082757208000711717 /* ApplicationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationError.swift; sourceTree = "<group>"; };
 		DB0B9149276E1BC5006F5CD0 /* OplKeyCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OplKeyCode.swift; sourceTree = "<group>"; };
-		DB0B918127710120006F5CD0 /* CGImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGImage.swift; sourceTree = "<group>"; };
 		DB0B91832771031F006F5CD0 /* aif.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = aif.lua; sourceTree = "<group>"; };
 		DB0B91842771031F006F5CD0 /* sis.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sis.lua; sourceTree = "<group>"; };
 		DB0B9190278369A4006F5CD0 /* BitmapFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitmapFont.swift; sourceTree = "<group>"; };
@@ -308,7 +310,7 @@
 		DB5AC96F275198A20043FE5C /* database.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = database.lua; sourceTree = "<group>"; };
 		DB5AC971275577980043FE5C /* mbm.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mbm.lua; sourceTree = "<group>"; };
 		DB5AC973275681510043FE5C /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
-		DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CGExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpoIoHandler_CGExtensions.swift; sourceTree = "<group>"; };
+		DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CoreGraphics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpoIoHandler_CoreGraphics.swift; sourceTree = "<group>"; };
 		DB5AC979275AC72A0043FE5C /* sound.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sound.lua; sourceTree = "<group>"; };
 		DB5AC97B275CD5690043FE5C /* opl.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = opl.lua; sourceTree = "<group>"; };
 		DB6B438327A55D1200625788 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -454,7 +456,6 @@
 				DB3FAC2D27C2CA49004155C1 /* CGRect.swift */,
 				D8FE60062757201600711717 /* Bundle.swift */,
 				D889134C274C17FF00794D55 /* CGContext.swift */,
-				DB0B918127710120006F5CD0 /* CGImage.swift */,
 				D889134E274C181F00794D55 /* CGPoint.swift */,
 				D87A62732752A67500075CB8 /* CGSize.swift */,
 				D8EB6FF9275995DB00FC139F /* Dictionary.swift */,
@@ -587,11 +588,13 @@
 		DB79FFE12742E52B005E904F /* swift */ = {
 			isa = PBXGroup;
 			children = (
-				DB79FFE52742E596005E904F /* OpoInterpreter.swift */,
-				DB79001B2746B88F005E904F /* OpoIoHandler.swift */,
-				DB0B9149276E1BC5006F5CD0 /* OplKeyCode.swift */,
-				DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CGExtensions.swift */,
+				D8C409852C3CF6DB00C9E857 /* CGImage.swift */,
 				DB9533FD27AC06A1001CF58D /* FlagSet.swift */,
+				DB0B9149276E1BC5006F5CD0 /* OplKeyCode.swift */,
+				DB79FFE52742E596005E904F /* OpoInterpreter.swift */,
+				DB5AC9752757B6ED0043FE5C /* OpoIoHandler_CoreGraphics.swift */,
+				D8C409622C3CF62900C9E857 /* OpoIoHandler_UIKit.swift */,
+				DB79001B2746B88F005E904F /* OpoIoHandler.swift */,
 			);
 			path = swift;
 			sourceTree = "<group>";
@@ -746,6 +749,7 @@
 				D884A3D52779025A008954A0 /* SystemFileSystem.swift in Sources */,
 				D80D65A8279DD2060020F994 /* Icon.swift in Sources */,
 				D8FE60052757177200711717 /* Settings.swift in Sources */,
+				D8C409632C3CF62900C9E857 /* OpoIoHandler_UIKit.swift in Sources */,
 				D81B875E2790DAAD00E71960 /* InstallerViewController.swift in Sources */,
 				D8DCD040277ACD7800760302 /* CanvasSprite.swift in Sources */,
 				D86724F22771672A009C7246 /* InterpreterThread.swift in Sources */,
@@ -762,10 +766,9 @@
 				D8891353274C186E00794D55 /* Canvas.swift in Sources */,
 				D8891345274BF25D00794D55 /* SwitchTableViewCell.swift in Sources */,
 				D82A37B827A9B43F00D8F5F4 /* DirectoryMonitor.swift in Sources */,
-				DB0B918227710120006F5CD0 /* CGImage.swift in Sources */,
 				D86E428A2799C0CC00D5596D /* UISplitViewController.swift in Sources */,
 				D889134D274C17FF00794D55 /* CGContext.swift in Sources */,
-				DB5AC9762757B6ED0043FE5C /* OpoIoHandler_CGExtensions.swift in Sources */,
+				DB5AC9762757B6ED0043FE5C /* OpoIoHandler_CoreGraphics.swift in Sources */,
 				D85F596F27ACB64E006AAF3B /* UIButton.swift in Sources */,
 				D80D65AC279DDF6B0020F994 /* IconCollectionViewLayout.swift in Sources */,
 				D889134A274BF3B000794D55 /* TranslucentNavigationController.swift in Sources */,
@@ -793,6 +796,7 @@
 				D89A607A2756A2CC00C9757F /* FileManager.swift in Sources */,
 				D8FE60072757201600711717 /* Bundle.swift in Sources */,
 				D8BA09722751BBEA00F4730D /* UIElement.swift in Sources */,
+				D8C409862C3CF6DB00C9E857 /* CGImage.swift in Sources */,
 				D889134F274C181F00794D55 /* CGPoint.swift in Sources */,
 				DB0B9191278369A4006F5CD0 /* BitmapFont.swift in Sources */,
 				D80A9CBE27A4A35E00E49AD8 /* UIDevice.swift in Sources */,

--- a/swift/CGImage.swift
+++ b/swift/CGImage.swift
@@ -315,7 +315,7 @@ extension CGImage {
     }
 
     // TODO: This should be a convenience constructor
-    static func from(bitmap: Graphics.Bitmap) -> CGImage {
+    public static func from(bitmap: Graphics.Bitmap) -> CGImage {
         switch bitmap.mode {
         case .gray2, .gray4, .gray16:
             // CoreGraphics doesn't seem to like <8bpp, so expand it

--- a/swift/OpoInterpreter.swift
+++ b/swift/OpoInterpreter.swift
@@ -689,7 +689,7 @@ private func getConfig(_ L: LuaState!) -> CInt {
     } else {
         print("Bad keyname to getConfig")
         return 0
-    }    
+    }
 }
 
 private func setConfig(_ L: LuaState!) -> CInt {
@@ -700,7 +700,7 @@ private func setConfig(_ L: LuaState!) -> CInt {
         iohandler.setConfig(key: key, value: val)
     } else {
         print("Bad key/val to setConfig")
-    }    
+    }
     return 0
 }
 
@@ -808,12 +808,12 @@ private extension Error {
     }
 }
 
-class OpoInterpreter {
+public class OpoInterpreter {
 
     private let L: LuaState
     var iohandler: OpoIoHandler
 
-    init() {
+    public init() {
         iohandler = DummyIoHandler() // For now...
         L = LuaState(libraries: [.package, .table, .io, .os, .string, .math, .utf8, .debug])
         L.setDefaultStringEncoding(kDefaultEpocEncoding)
@@ -1004,7 +1004,7 @@ class OpoInterpreter {
         return L.toAppInfo(-1)
     }
 
-    func getMbmBitmaps(path: String) -> [Graphics.Bitmap]? {
+    public func getMbmBitmaps(path: String) -> [Graphics.Bitmap]? {
         let top = L.gettop()
         defer {
             L.settop(top)

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -20,16 +20,16 @@
 
 import Foundation
 
-struct Graphics {
+public struct Graphics {
 
-    struct Size: Equatable, Comparable, Codable {
+    public struct Size: Equatable, Comparable, Codable {
 
-        static func < (lhs: Graphics.Size, rhs: Graphics.Size) -> Bool {
+        public static func < (lhs: Graphics.Size, rhs: Graphics.Size) -> Bool {
             lhs.width < rhs.width && lhs.height < rhs.height
         }
 
-        let width: Int
-        let height: Int
+        public let width: Int
+        public let height: Int
 
         enum CodingKeys: String, CodingKey {
             case width = "w"
@@ -38,6 +38,12 @@ struct Graphics {
 
         static let icon = Self(width: 48, height: 48)
         static let zero = Self(width: 0, height: 0)
+
+        public init(width: Int, height: Int) {
+            self.width = width
+            self.height = height
+        }
+
     }
 
     struct Point: Equatable, Codable {
@@ -109,8 +115,9 @@ struct Graphics {
         static let white = Self(r: 255, g: 255, b: 255)
     }
 
-    struct Bitmap: Codable {
-        enum Mode: Int, Codable {
+    public struct Bitmap: Codable {
+
+        public enum Mode: Int, Codable {
             case gray2 = 0 // ie 1bpp
             case gray4 = 1 // ie 2bpp
             case gray16 = 2 // ie 4bpp grayscale
@@ -121,19 +128,22 @@ struct Graphics {
             case color16M = 7 // 24bpp color
             case color4K = 9 // ie 12bpp color
         }
-        let mode: Mode
-        let width: Int
-        let height: Int
-        let stride: Int
-        let imgData: Data
+
+        public let mode: Mode
+        public let width: Int
+        public let height: Int
+        public let stride: Int
+        public let imgData: Data
         // TODO palette info also needed, in due course
 
-        var size: Size {
+        public var size: Size {
             return Size(width: width, height: height)
         }
-        var isColor: Bool {
+
+        public var isColor: Bool {
             return mode.isColor
         }
+        
     }
 
     struct MaskedBitmap {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -22,14 +22,14 @@ import Foundation
 
 public struct Graphics {
 
-    public struct Size: Equatable, Comparable, Codable {
+    struct Size: Equatable, Comparable, Codable {
 
-        public static func < (lhs: Graphics.Size, rhs: Graphics.Size) -> Bool {
+        static func < (lhs: Graphics.Size, rhs: Graphics.Size) -> Bool {
             lhs.width < rhs.width && lhs.height < rhs.height
         }
 
-        public let width: Int
-        public let height: Int
+        let width: Int
+        let height: Int
 
         enum CodingKeys: String, CodingKey {
             case width = "w"
@@ -38,12 +38,6 @@ public struct Graphics {
 
         static let icon = Self(width: 48, height: 48)
         static let zero = Self(width: 0, height: 0)
-
-        public init(width: Int, height: Int) {
-            self.width = width
-            self.height = height
-        }
-
     }
 
     struct Point: Equatable, Codable {
@@ -117,7 +111,7 @@ public struct Graphics {
 
     public struct Bitmap: Codable {
 
-        public enum Mode: Int, Codable {
+        enum Mode: Int, Codable {
             case gray2 = 0 // ie 1bpp
             case gray4 = 1 // ie 2bpp
             case gray16 = 2 // ie 4bpp grayscale
@@ -128,22 +122,20 @@ public struct Graphics {
             case color16M = 7 // 24bpp color
             case color4K = 9 // ie 12bpp color
         }
-
-        public let mode: Mode
-        public let width: Int
-        public let height: Int
-        public let stride: Int
-        public let imgData: Data
+        
+        let mode: Mode
+        let width: Int
+        let height: Int
+        let stride: Int
+        let imgData: Data
         // TODO palette info also needed, in due course
 
-        public var size: Size {
+        var size: Size {
             return Size(width: width, height: height)
         }
-
-        public var isColor: Bool {
+        var isColor: Bool {
             return mode.isColor
         }
-        
     }
 
     struct MaskedBitmap {

--- a/swift/OpoIoHandler_CoreGraphics.swift
+++ b/swift/OpoIoHandler_CoreGraphics.swift
@@ -19,7 +19,6 @@
 // SOFTWARE.
 
 import CoreGraphics
-import UIKit
 
 extension Graphics.Color {
     func cgColor() -> CGColor {
@@ -42,41 +41,5 @@ extension Graphics.Point {
 extension Graphics.Rect {
     func cgRect() -> CGRect {
         return CGRect(x: self.origin.x, y: self.origin.y, width: self.width, height: self.height)
-    }
-}
-
-extension Graphics.FontInfo {
-    func toUiFont() -> UIFont? {
-        let sz = CGFloat(self.size)
-        let uiFontName: String
-        var traits: UIFontDescriptor.SymbolicTraits = []
-        if self.flags.contains(.bold) || self.flags.contains(.boldHint) {
-            traits.insert(.traitBold)
-        }
-        switch self.face {
-        case .arial:
-            uiFontName = "Arial"
-        case .times:
-            uiFontName = "Times"
-        case .courier:
-            uiFontName = "Courier"
-        case .tiny:
-            uiFontName = "Courier" // Who knows...
-        case .squashed:
-            uiFontName = "Helvetica Neue"
-            traits.insert(.traitCondensed)
-        case .digit, .eiksym:
-            return nil
-        }
-
-        var desc = UIFontDescriptor(name: uiFontName, size: sz)
-        if let newDesc = desc.withSymbolicTraits(traits) {
-            desc = newDesc
-        }
-        return UIFont(descriptor: desc, size: sz)
-    }
-
-    func toBitmapFont() -> BitmapFontInfo? {
-        return BitmapFontInfo(uid: self.uid)
     }
 }

--- a/swift/OpoIoHandler_UIKit.swift
+++ b/swift/OpoIoHandler_UIKit.swift
@@ -1,0 +1,61 @@
+// Copyright (c) 2021-2024 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#if os(iOS)
+import UIKit
+
+ extension Graphics.FontInfo {
+     func toUiFont() -> UIFont? {
+         let sz = CGFloat(self.size)
+         let uiFontName: String
+         var traits: UIFontDescriptor.SymbolicTraits = []
+         if self.flags.contains(.bold) || self.flags.contains(.boldHint) {
+             traits.insert(.traitBold)
+         }
+         switch self.face {
+         case .arial:
+             uiFontName = "Arial"
+         case .times:
+             uiFontName = "Times"
+         case .courier:
+             uiFontName = "Courier"
+         case .tiny:
+             uiFontName = "Courier" // Who knows...
+         case .squashed:
+             uiFontName = "Helvetica Neue"
+             traits.insert(.traitCondensed)
+         case .digit, .eiksym:
+             return nil
+         }
+
+         var desc = UIFontDescriptor(name: uiFontName, size: sz)
+         if let newDesc = desc.withSymbolicTraits(traits) {
+             desc = newDesc
+         }
+         return UIFont(descriptor: desc, size: sz)
+     }
+
+     func toBitmapFont() -> BitmapFontInfo? {
+         return BitmapFontInfo(uid: self.uid)
+     }
+ }
+
+#endif


### PR DESCRIPTION
This small change moves towards allowing the OpoLua core functionality to be reused in other projects by marking some functions and classes as public and moving the `CGImage` extensions into the 'swift' directory so this can be use standalone (alongside the 'src' directory which contains the corresponding Lua source).

It's unclear what the long-term approach to allowing code reuse across projects will be, but this allows for initial experimentation.