### PR TITLE
fix: Assorted small fixes

### DIFF
--- a/src/modules/toolbar.lua
+++ b/src/modules/toolbar.lua
@@ -44,7 +44,7 @@ local KTbClockPosX = 4
 local KTbClockHeight = 64
 
 -- Global vars
-local visibleVar
+local TbVis, TbMenuSym
 
 -- Actual state
 local tbWinId
@@ -61,8 +61,10 @@ local defaultIcon
 function TBarLink(appLink)
     local tbWidthVar = runtime:declareGlobal("TbWidth%")
     tbWidthVar(KTbWidth)
-    visibleVar = runtime:declareGlobal("TbVis%")
-    visibleVar(0)
+    TbVis = runtime:declareGlobal("TbVis%")
+    TbVis(0)
+    TbMenuSym = runtime:declareGlobal("TbMenuSym%")
+    TbMenuSym(KMenuCheckBox)
     runtime:callProc(appLink:upper())
 end
 
@@ -278,7 +280,8 @@ function TBarShow()
     local prevId = gIDENTITY()
     gUSE(tbWinId)
     gVISIBLE(true)
-    visibleVar(-1)
+    TbVis(-1)
+    TbMenuSym(KMenuCheckBox | KMenuSymbolOn)
     gUSE(prevId)
 end
 
@@ -286,7 +289,8 @@ function TBarHide()
     local prevId = gIDENTITY()
     gUSE(tbWinId)
     gVISIBLE(false)
-    visibleVar(0)
+    TbVis(0)
+    TbMenuSym(KMenuCheckBox)
     gUSE(prevId)
 end
 

--- a/src/opl.lua
+++ b/src/opl.lua
@@ -972,6 +972,10 @@ function IOREAD(h, maxLen)
     end
     assert(f.pos, "Cannot IOREAD a non-file handle!")
 
+    if f.pos > #f.data then
+        return nil, KErrEof
+    end
+
     if f.mode & KIoOpenFormatText > 0 then
         local startPos, endPos = f.data:find("\r?\n", f.pos)
         if startPos then
@@ -990,7 +994,11 @@ function IOREAD(h, maxLen)
     else
         local data = f.data:sub(f.pos, f.pos + maxLen - 1)
         -- printf("IOREAD pos=%d len=%d data=%s\n", f.pos, #data, hexEscape(data))
-        f.pos = f.pos + #data
+        if #data == 0 then
+            f.pos = #f.data + 1 -- So we error next read
+        else
+            f.pos = f.pos + #data
+        end
         return data
     end
 end

--- a/src/ops.lua
+++ b/src/ops.lua
@@ -1159,7 +1159,8 @@ end
 function CallProcByStringExpr_dump(runtime)
     local numParams = runtime:IP8()
     local type = runtime:IP8()
-    return fmt("nargs=%d type=%c", numParams, type)
+    local typeStr = type == 0 and "" or string.format("%c", type)
+    return fmt("nargs=%d type=%s", numParams, typeStr)
 end
 
 function PercentLessThan(stack, runtime) -- 0x6C
@@ -2430,13 +2431,14 @@ function CallOpxFunc_dump(runtime)
     local opx = runtime:moduleForProc(runtime:currentProc()).opxTable[1 + opxNo]
     local fnName
     if opx then
-        local ok, module = pcall(require, fmt("opx.%s", opx.filename))
+        local modName = "opx." .. opx.name:lower()
+        local ok, module = pcall(require, modName)
         if ok then
             fnName = module.fns[fnIdx]
         end
     end
 
-    return fmt("%d %d (%s %s)", opxNo, fnIdx, opx and opx.filename or "?", fnName or "?")
+    return fmt("%d %d (%s %s)", opxNo, fnIdx, opx and opx.name or "?", fnName or "?")
 end
 
 function Statement32(stack, runtime) -- 0x119

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -980,6 +980,11 @@ function Runtime:pcallProc(procName, ...)
             addStacktraceToError(self, err, callingFrame)
             -- print(err)
             self.errorLocation = fmt("Error in %s\\%s", self:moduleForProc(self.frame.proc).name, self.frame.proc.name)
+
+            if err.code and err.code == KStopErr then
+                printf("Interrupted!\n%s\n", err)
+            end
+
             if err.code and err.code ~= KStopErr then
                 self.errorValue = err.code
                 -- An error code that might potentially be handled by a Trap or OnErr


### PR DESCRIPTION
* fixed crash in BikLog5 due to not declaring TbMenuSym%
* fixed lack of EOF error in IOREAD (fixes #213)
* removed null byte from CallProcByStringExpr in dumpopo.lua output (as noted on #328).
* fixed missing OPX info in CallOpxFunc dumpopo.lua output
* "Force close program" now dumps the stacktrace to the console