### PR TITLE
feat: Improved SIS file handling

### DIFF
--- a/OpoLua.xcodeproj/project.pbxproj
+++ b/OpoLua.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D80D65AC279DDF6B0020F994 /* IconCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */; };
 		D80D65AE279DE0CE0020F994 /* RunningProgramsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AD279DE0CE0020F994 /* RunningProgramsViewController.swift */; };
 		D80D65B0279E31220020F994 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D65AF279E31220020F994 /* Configuration.swift */; };
+		D811A3AC2DEE4D6B00E5CCF7 /* SisInstallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D811A3AB2DEE4D6800E5CCF7 /* SisInstallError.swift */; };
 		D815C6602DE145CC009EABFE /* lua-license in Resources */ = {isa = PBXBuildFile; fileRef = D815C65E2DE145CC009EABFE /* lua-license */; };
 		D815C6612DE145CC009EABFE /* opolua-license in Resources */ = {isa = PBXBuildFile; fileRef = D815C65F2DE145CC009EABFE /* opolua-license */; };
 		D81B4A4927B5AA650051B092 /* IndexableLocationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B4A4827B5AA650051B092 /* IndexableLocationObserver.swift */; };
@@ -151,6 +152,7 @@
 		D80D65AB279DDF6B0020F994 /* IconCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconCollectionViewLayout.swift; sourceTree = "<group>"; };
 		D80D65AD279DE0CE0020F994 /* RunningProgramsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningProgramsViewController.swift; sourceTree = "<group>"; };
 		D80D65AF279E31220020F994 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		D811A3AB2DEE4D6800E5CCF7 /* SisInstallError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SisInstallError.swift; sourceTree = "<group>"; };
 		D815C65E2DE145CC009EABFE /* lua-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "lua-license"; sourceTree = "<group>"; };
 		D815C65F2DE145CC009EABFE /* opolua-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "opolua-license"; sourceTree = "<group>"; };
 		D81B4A4827B5AA650051B092 /* IndexableLocationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexableLocationObserver.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 		D889134B274C17F300794D55 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				D811A3AB2DEE4D6800E5CCF7 /* SisInstallError.swift */,
 				DB3FAC2D27C2CA49004155C1 /* CGRect.swift */,
 				D8FE60062757201600711717 /* Bundle.swift */,
 				D889134C274C17FF00794D55 /* CGContext.swift */,
@@ -698,6 +701,7 @@
 				D8D184F527BACAB5004DDFFD /* SoundViewController.swift in Sources */,
 				DB5AC974275681510043FE5C /* CanvasView.swift in Sources */,
 				DB79FFE62742E596005E904F /* OpoInterpreter.swift in Sources */,
+				D811A3AC2DEE4D6B00E5CCF7 /* SisInstallError.swift in Sources */,
 				D8C712A4275AF50D00D83A3E /* ConcurrentQueue.swift in Sources */,
 				DB79FFDF2742DEBE005E904F /* AppDelegate.swift in Sources */,
 				D8EB6FFA275995DB00FC139F /* Dictionary.swift in Sources */,

--- a/OpoLua/Extensions/SisInstallError.swift
+++ b/OpoLua/Extensions/SisInstallError.swift
@@ -20,6 +20,6 @@
 
 import Foundation
 
-extension SisInstallError: LocalizedError {
+extension Sis.InstallError: LocalizedError {
     public var errorDescription: String? { return self.description }
 }

--- a/OpoLua/Extensions/SisInstallError.swift
+++ b/OpoLua/Extensions/SisInstallError.swift
@@ -1,0 +1,25 @@
+// Copyright (c) 2021-2025 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension SisInstallError: LocalizedError {
+    public var errorDescription: String? { return self.description }
+}

--- a/OpoLua/Model/FileSystem.swift
+++ b/OpoLua/Model/FileSystem.swift
@@ -74,7 +74,7 @@ extension FileSystem {
             }
             do {
                 try fileManager.removeItem(atPath: path)
-                return .err(.none)
+                return .success
             } catch {
                 return .err(.notReady)
             }
@@ -93,7 +93,7 @@ extension FileSystem {
             }
             do {
                 try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-                return .err(.none)
+                return .success
             } catch {
                 return .err(.notReady)
             }
@@ -135,7 +135,7 @@ extension FileSystem {
                 }
             }
             let ok = fileManager.createFile(atPath: path, contents: data)
-            return .err(ok ? .none : .notReady)
+            return ok ? .success : .err(.notReady)
         case .read:
             if let result = fileManager.contents(atPath: nativePath.path) {
                 return .data(result)
@@ -167,7 +167,7 @@ extension FileSystem {
             }
             do {
                 try fileManager.moveItem(atPath: path, toPath: nativeDest)
-                return .err(.none)
+                return .success
             } catch {
                 return .err(.notReady)
             }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -76,19 +76,26 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
+    func sisInstallBegin(info: SisFile) -> Bool {
+        return true
+    }
+
     func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool {
-        print("TODO sisInstallQuery \(text)")
+        // print("TODO sisInstallQuery \(text)")
         return true
     }
 
     func sisInstallGetLanguage(_ languages: [String]) -> String? {
-        print("TODO sisInstallGetLanguage \(languages)")
+        // print("TODO sisInstallGetLanguage \(languages)")
         return languages[0] // Whatever is first
     }
 
     func sisInstallGetDrive() -> String? {
-        print("TODO sisInstallGetDrive")
+        // print("TODO sisInstallGetDrive")
         return "C"
     }
-    
+
+    func sisInstallComplete() {
+    }
+
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -76,4 +76,9 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
+    func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool {
+        print("TODO sisInstallQuery \(text)")
+        return true
+    }
+
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -86,4 +86,9 @@ extension Installer: SisInstallIoHandler {
         return languages[0] // Whatever is first
     }
 
+    func sisInstallGetDrive() -> String? {
+        print("TODO sisInstallGetDrive")
+        return "C"
+    }
+    
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -81,6 +81,7 @@ extension Installer: SisInstallIoHandler {
     }
 
     func sisInstallBegin(sis: Sis.File, context: Sis.BeginContext) -> Sis.BeginResult {
+        // print("Installing v\(sis.version)")
         return .install(sis.languages[0], "C")
     }
 

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -81,4 +81,9 @@ extension Installer: SisInstallIoHandler {
         return true
     }
 
+    func sisInstallGetLanguage(_ languages: [String]) -> String? {
+        print("TODO sisInstallGetLanguage \(languages)")
+        return languages[0] // Whatever is first
+    }
+
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -76,22 +76,13 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
-    func sisInstallBegin(info: SisFile) -> Bool {
-        return true
+    func sisInstallBegin(info: SisFile, driveRequired: Bool) -> SisInstallBeginResult  {
+        return .install(info.languages[0], "C")
     }
 
     func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool {
         print("TODO sisInstallQuery \(text)")
         return true
-    }
-
-    func sisInstallGetLanguage(_ languages: [String]) -> String {
-        // print("TODO sisInstallGetLanguage \(languages)")
-        return languages[0] // Whatever is first
-    }
-
-    func sisInstallGetDrive() -> String {
-        return "C"
     }
 
     func sisInstallRollback() -> Bool {

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -80,7 +80,7 @@ extension Installer: SisInstallIoHandler {
         return .notImplemented
     }
 
-    func sisInstallBegin(sis: Sis.File, driveRequired: Bool, replacing: Sis.File?) -> Sis.BeginResult {
+    func sisInstallBegin(sis: Sis.File, context: Sis.BeginContext) -> Sis.BeginResult {
         return .install(sis.languages[0], "C")
     }
 

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -76,21 +76,21 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
-    func sisInstallBegin(info: SisFile, driveRequired: Bool) -> SisInstallBeginResult  {
-        return .install(info.languages[0], "C")
+    func sisInstallBegin(sis: SisFile, driveRequired: Bool) -> SisInstallBeginResult  {
+        return .install(sis.languages[0], "C")
     }
 
-    func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool {
+    func sisInstallQuery(sis: SisFile, text: String, type: InstallerQueryType) -> Bool {
         print("TODO sisInstallQuery \(text)")
         return true
     }
 
-    func sisInstallRollback() -> Bool {
+    func sisInstallRollback(sis: SisFile) -> Bool {
         print("sisInstallRollback")
         return false // rollback not needed since we install to a sandbox.
     }
 
-    func sisInstallComplete() {
+    func sisInstallComplete(sis: SisFile) {
     }
 
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -76,21 +76,25 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
-    func sisInstallBegin(sis: SisFile, driveRequired: Bool) -> SisInstallBeginResult  {
+    func sisGetStubs() -> Sis.GetStubsResult {
+        return .notImplemented
+    }
+
+    func sisInstallBegin(sis: Sis.File, driveRequired: Bool, replacing: Sis.File?) -> Sis.BeginResult {
         return .install(sis.languages[0], "C")
     }
 
-    func sisInstallQuery(sis: SisFile, text: String, type: InstallerQueryType) -> Bool {
+    func sisInstallQuery(sis: Sis.File, text: String, type: Sis.QueryType) -> Bool {
         print("TODO sisInstallQuery \(text)")
         return true
     }
 
-    func sisInstallRollback(sis: SisFile) -> Bool {
+    func sisInstallRollback(sis: Sis.File) -> Bool {
         print("sisInstallRollback")
         return false // rollback not needed since we install to a sandbox.
     }
 
-    func sisInstallComplete(sis: SisFile) {
+    func sisInstallComplete(sis: Sis.File) {
     }
 
 }

--- a/OpoLua/Model/Installer.swift
+++ b/OpoLua/Model/Installer.swift
@@ -81,18 +81,22 @@ extension Installer: SisInstallIoHandler {
     }
 
     func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool {
-        // print("TODO sisInstallQuery \(text)")
+        print("TODO sisInstallQuery \(text)")
         return true
     }
 
-    func sisInstallGetLanguage(_ languages: [String]) -> String? {
+    func sisInstallGetLanguage(_ languages: [String]) -> String {
         // print("TODO sisInstallGetLanguage \(languages)")
         return languages[0] // Whatever is first
     }
 
-    func sisInstallGetDrive() -> String? {
-        // print("TODO sisInstallGetDrive")
+    func sisInstallGetDrive() -> String {
         return "C"
+    }
+
+    func sisInstallRollback() -> Bool {
+        print("sisInstallRollback")
+        return false // rollback not needed since we install to a sandbox.
     }
 
     func sisInstallComplete() {

--- a/OpoLua/Model/Program.swift
+++ b/OpoLua/Model/Program.swift
@@ -168,6 +168,8 @@ class Program {
             switch key {
             case .clockFormat:
                 oplConfig[key] = "0" // analog
+            case .locale:
+                oplConfig[key] = "en_GB"
             }
         }
         
@@ -525,6 +527,8 @@ extension Program: OpoIoHandler {
             case .clockFormat:
                 let clockType: Settings.ClockType = value == "1" ? .digital : .analog
                 settings.clockType = clockType
+            case .locale:
+                break // TODO persist this? It's not currently settable, so...
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Various useful resources which aided greatly in reverse-engineering the OPL and 
 * https://github.com/opl-dev/opl-dev
 * https://web.archive.org/web/20070716134804/http://3lib.ukonline.co.uk/progindex.htm
 * https://web.archive.org/web/20060505220702/http://www.allaboutopl.com/wiki/OPLCommandsListing?v=kbu
-* https://thoukydides.github.io/riscos-psifs/sis.html
+* https://www.thouky.co.uk/software/psifs/sis.html
 * http://www.koeniglich.de/epoc32_fileformats.txt
 * https://frodo.looijaard.name/psifiles/MBM_File
 * http://www.davros.org/psion/psionics/

--- a/src/compile.lua
+++ b/src/compile.lua
@@ -39,7 +39,7 @@ function main()
 
     if args.help then
         print([[
-Syntax: compile.lua [options] <filename> [<ouput>]
+Syntax: compile.lua [options] <filename> [<output>]
 
 Compile a Series 5 era OPL program. If neither <output> nor --dump are
 specified, the result is written to <filename>.opo alongside <filename>.

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -309,7 +309,7 @@ end
 
 function sisInstallBegin(sisInfo)
     printf("sisInstallBegin %s v%s\n", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
-    return true -- ie proceed with install
+    return { type = "install", drive = "C", lang = sisInfo.languages[1] }
 end
 
 function sisInstallRollback()
@@ -317,20 +317,12 @@ function sisInstallRollback()
 end
 
 function sisInstallComplete()
-    -- print("sisInstallComplete")
+    print("sisInstallComplete")
 end
 
 function sisInstallQuery(text, type)
     print(text)
     return true
-end
-
-function sisInstallGetLanguage(candidates)
-    return getConfig("locale")
-end
-
-function sisInstallGetDrive()
-    return "C"
 end
 
 return _ENV

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -312,15 +312,17 @@ function sisInstallBegin(sisInfo)
     return { type = "install", drive = "C", lang = sisInfo.languages[1] }
 end
 
-function sisInstallRollback()
+function sisInstallRollback(sisInfo)
+    -- printf("sisInstallRollback %s\n", sisInfo.name[sisInfo.languages[1]])
+    -- return true
     return false -- We don't really need rollback on the command line?
 end
 
-function sisInstallComplete()
-    print("sisInstallComplete")
+function sisInstallComplete(sisInfo)
+    printf("sisInstallComplete %s\n", sisInfo.name[sisInfo.languages[1]])
 end
 
-function sisInstallQuery(text, type)
+function sisInstallQuery(sisInfo, text, type)
     print(text)
     return true
 end

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -311,10 +311,10 @@ function sisGetStubs()
     return "notimplemented"
 end
 
-function sisInstallBegin(sisInfo, hasDriveChoice, replacing)
+function sisInstallBegin(sisInfo, context)
     printf("sisInstallBegin %s v%s", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
-    if replacing then
-        printf(" replacing v%s", replacing.version)
+    if context.replacing then
+        printf(" replacing v%s", context.replacing.version)
     end
     printf("\n")
 

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -308,8 +308,12 @@ function setEra(era)
 end
 
 function sisInstallBegin(sisInfo)
-    -- print("sisInstallBegin", dump(sisInfo))
+    printf("sisInstallBegin %s v%s\n", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
     return true -- ie proceed with install
+end
+
+function sisInstallRollback()
+    return false -- We don't really need rollback on the command line?
 end
 
 function sisInstallComplete()
@@ -326,7 +330,6 @@ function sisInstallGetLanguage(candidates)
 end
 
 function sisInstallGetDrive()
-    -- print("sisInstallGetDrive")
     return "C"
 end
 

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -312,4 +312,8 @@ function sisInstallQuery(text, type)
     return true
 end
 
+function sisInstallGetLanguage(candidates)
+    return getConfig("locale")
+end
+
 return _ENV

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -316,4 +316,8 @@ function sisInstallGetLanguage(candidates)
     return getConfig("locale")
 end
 
+function sisInstallGetDrive()
+    return "C"
+end
+
 return _ENV

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -229,7 +229,7 @@ function fsop(cmd, path, ...)
         if ok then
             local result = {}
             for line in data:gmatch("([^\n]+)") do
-                table.insert(result, oplpath.join(filename, line))
+                table.insert(result, oplpath.join(path, line))
             end
             return result
         else
@@ -311,8 +311,13 @@ function sisGetStubs()
     return "notimplemented"
 end
 
-function sisInstallBegin(sisInfo)
-    printf("sisInstallBegin %s v%s\n", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
+function sisInstallBegin(sisInfo, hasDriveChoice, replacing)
+    printf("sisInstallBegin %s v%s", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
+    if replacing then
+        printf(" replacing v%s", replacing.version)
+    end
+    printf("\n")
+
     return { type = "install", drive = "C", lang = sisInfo.languages[1] }
 end
 

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -229,11 +229,11 @@ function fsop(cmd, path, ...)
         if ok then
             local result = {}
             for line in data:gmatch("([^\n]+)") do
-                table.insert(result, line)
+                table.insert(result, oplpath.join(filename, line))
             end
             return result
         else
-            printf("defaultiohandler: ls command failed (%d)\n", val, data)
+            -- printf("defaultiohandler: ls command failed (%d)\n", val, data)
             return nil, KErrNotReady
         end
     else
@@ -305,6 +305,10 @@ function runApp(prog, doc)
 end
 
 function setEra(era)
+end
+
+function sisGetStubs()
+    return "notimplemented"
 end
 
 function sisInstallBegin(sisInfo)

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -307,6 +307,15 @@ end
 function setEra(era)
 end
 
+function sisInstallBegin(sisInfo)
+    -- print("sisInstallBegin", dump(sisInfo))
+    return true -- ie proceed with install
+end
+
+function sisInstallComplete()
+    -- print("sisInstallComplete")
+end
+
 function sisInstallQuery(text, type)
     print(text)
     return true
@@ -317,6 +326,7 @@ function sisInstallGetLanguage(candidates)
 end
 
 function sisInstallGetDrive()
+    -- print("sisInstallGetDrive")
     return "C"
 end
 

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -31,8 +31,8 @@ local fmt = string.format
 
 local statusRequests = {}
 
-function print(val)
-    printf("%s", val:gsub("[\x00-\x1F]", textReplacements))
+function iohPrint(val)
+    printf("%s", val:gsub(textReplacementsMatch, textReplacements))
 end
 
 function textEditor(params)
@@ -278,12 +278,14 @@ end
 function opsync()
 end
 
+local config = { locale = "en_GB", clockFormat = "0" }
+
 function getConfig(key)
-    return ""
+    return config[key] or ""
 end
 
 function setConfig(key, val)
-    printf("setConfig(%q, %q)\n", key, val)
+    config[key] = val
 end
 
 function setAppTitle(title)
@@ -303,6 +305,11 @@ function runApp(prog, doc)
 end
 
 function setEra(era)
+end
+
+function sisInstallQuery(text, type)
+    print(text)
+    return true
 end
 
 return _ENV

--- a/src/defaultiohandler.lua
+++ b/src/defaultiohandler.lua
@@ -312,9 +312,10 @@ function sisGetStubs()
 end
 
 function sisInstallBegin(sisInfo, context)
-    printf("sisInstallBegin %s v%s", sisInfo.name[sisInfo.languages[1]], sisInfo.version)
+    printf("sisInstallBegin %s v%d.%02d", sisInfo.name[sisInfo.languages[1]], sisInfo.version.major, sisInfo.version.minor)
     if context.replacing then
-        printf(" replacing v%s", context.replacing.version)
+        local v = context.replacing.version
+        printf(" replacing v%d.%02d", v.major, v.minor)
     end
     printf("\n")
 

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -195,7 +195,7 @@ function manifestToUtf8(manifest)
     return result
 end
 
-function sisInstallQueryInteractive(text, type)
+function sisInstallQueryInteractive(info, text, type)
     print(text)
     if type == sis.FileTextDetails.Continue then
         print("-- Press any key to continue --")
@@ -214,7 +214,7 @@ function sisInstallQueryInteractive(text, type)
     end
 end
 
-function sisInstallQueryQuiet(text, type)
+function sisInstallQueryQuiet(info, text, type)
     return true
 end
 

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -113,7 +113,10 @@ Options:
             iohandler.setConfig("locale", args.language)
         end
 
-        sis.installSis(path_basename(args.filename), data, iohandler, args.stub, args.verbose)
+        local err = sis.installSis(path_basename(args.filename), data, iohandler, args.stub, args.verbose)
+        if err then
+            printf("Install failed, err=%s\n", err.type)
+        end
     else
         local sisfile = sis.parseSisFile(data, args.verbose)
         if args.json then

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -117,7 +117,7 @@ Options:
     else
         local sisfile = sis.parseSisFile(data, args.verbose)
         if args.json then
-            local manifest = manifestToUtf8(sis.makeManifest(sisfile, args.language))
+            local manifest = manifestToUtf8(sis.makeManifest(sisfile, args.language, true))
             print(json.encode(manifest))
         else
             describeSis(sisfile, "")

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -26,25 +26,89 @@ SOFTWARE.
 
 dofile(arg[0]:match("^(.-)[a-z]+%.lua$").."cmdline.lua")
 
+local function path_join(path, component)
+    local sep = path:match("/^") and "" or "/"
+    return path..sep..component
+end
+
 function main()
     local args = getopt({
         "filename",
         "dest",
         verbose = true, v = "verbose",
         json = true, j = "json",
-        nolangs = true, n = "nolangs",
+        quiet = true, q = "quiet",
+        interactive = true, i = "interactive",
+        language = string, l = "language",
+        help = true, h = "help",
     })
 
+    if args.help or args.filename == nil then
+        print([[
+Syntax: dumpsis.lua [options] <filename> [<output>]
+
+If no <output> is supplied, list the contents of the SIS <filename> to stdout.
+If <output> is supplied, extract the SIS file to that location.
+
+Options:
+    --json, -j
+        When listing the SIS file, output in JSON format. Has no effect if
+        <output> is specified.
+
+    --language, -l
+        When extracting the SIS, control which file language is extracted. If
+        specified with --json and without <output>, only mention this language
+        in the JSON output rather than listing all of them. If not
+        specified, extraction defaults to using the en_GB resources (or next
+        best).
+
+    --quiet, -q
+        By default any show-on-install text files are printed to stdout when
+        extracting a SIS. Specify --quiet to suppress this. Either way, all
+        queries are automatically accepted unless --interactive is specified.
+
+    --interactive, -i
+        Prompt after any show-on-install text files are printed. Cannot be
+        combined with --quiet.
+
+    --verbose, -v
+        When listing the SIS file, print extra debug information.
+]])
+        os.exit(true)
+    end
+
+    if args.quiet and args.interactive then
+        error("Cannot specify both --quiet and --interactive")
+    end
+
     sis = require("sis")
+
+    if args.language then
+        assert(sis.Locales[args.language], "Bad --language argument")
+    end
+
     cp1252 = require("cp1252")
     local data = readFile(args.filename)
-    local sisfile = sis.parseSisFile(data, args.verbose)
 
     if args.dest then
-        installSis(sisfile, args.dest)
+        local iohandler = require("defaultiohandler")
+        iohandler.fsmap("C:\\", path_join(args.dest, ""))
+        if args.interactive then
+            setTerminalCharMode(true)
+            iohandler.sisInstallQuery = sisInstallQueryInteractive
+        elseif args.quiet then
+            iohandler.sisInstallQuery = sisInstallQueryQuiet
+        end
+
+        if args.language then
+            iohandler.setConfig("locale", args.language)
+        end
+
+        sis.installSis(data, iohandler, args.verbose)
     else
+        local sisfile = sis.parseSisFile(data, args.verbose)
         if args.json then
-            local manifest = manifestToUtf8(sis.makeManifest(sisfile, not args.nolangs))
+            local manifest = manifestToUtf8(sis.makeManifest(sisfile, args.language))
             print(json.encode(manifest))
         else
             describeSis(sisfile, "")
@@ -88,41 +152,13 @@ function describeSis(sisfile, indent)
     end
 end
 
-function installSis(sisfile, dest)
-    local langIdx = sis.getBestLangIdx(sisfile.langs)
-    for _, file in ipairs(sisfile.files) do
-        if file.type == sis.FileType.File then
-            if file.data or (file.langData and file.langData[langIdx]) then
-                extractFile(file, langIdx, dest)
-            else
-                printf("Warning: Skipping truncated file %s\n", file.dest)
-            end
-        elseif file.type == sis.FileType.SisComponent then
-            local componentSis = sis.parseSisFile(file.data)
-            installSis(componentSis, dest)
-        end
-    end
-end
-
-function extractFile(file, langIdx, dest)
-    local destName = cp1252.toUtf8(file.dest)
-    local outName = dest.."/c/"..destName:sub(4):gsub("\\", "/")
-    local dir = oplpath.dirname(outName)
-    -- print(dir)
-    os.execute(string.format('mkdir -p "%s"', dir))
-    local data = file.data
-    if not data then
-        data = file.langData[langIdx]
-    end
-    writeFile(outName, data)
-end
-
 function manifestToUtf8(manifest)
     local result = {
         type = manifest.type,
         version = manifest.version,
         uid = manifest.uid,
         files = {},
+        languages = manifest.languages,
     }
     if type(manifest.name) == "string" then
         result.name = cp1252.toUtf8(manifest.name)
@@ -145,6 +181,29 @@ function manifestToUtf8(manifest)
     end
 
     return result
+end
+
+function sisInstallQueryInteractive(text, type)
+    print(text)
+    if type == sis.FileTextDetails.Continue then
+        print("-- Press any key to continue --")
+        io.stdin:read(1)
+        return true
+    else
+        print("-- Press [Y]es or [N]o to continue --")
+        while true do
+            local ch = io.stdin:read(1)
+            if ch == "Y" or ch == "y" then
+                return true
+            elseif ch == "N" or ch == "n" then
+                return false
+            end
+        end
+    end
+end
+
+function sisInstallQueryQuiet(text, type)
+    return true
 end
 
 pcallMain()

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -31,6 +31,10 @@ local function path_join(path, component)
     return path..sep..component
 end
 
+local function path_basename(path)
+    return (path:match("/?([^/]+)$"))
+end
+
 function main()
     local args = getopt({
         "filename",
@@ -40,6 +44,7 @@ function main()
         quiet = true, q = "quiet",
         interactive = true, i = "interactive",
         language = string, l = "language",
+        stub = true, s = "stub",
         help = true, h = "help",
     })
 
@@ -48,7 +53,8 @@ function main()
 Syntax: dumpsis.lua [options] <filename> [<output>]
 
 If no <output> is supplied, list the contents of the SIS <filename> to stdout.
-If <output> is supplied, extract the SIS file to that location.
+If <output> is supplied, extract the SIS file to that location, treating that
+location as the root of a hypothetical C: drive.
 
 Options:
     --json, -j
@@ -70,6 +76,9 @@ Options:
     --interactive, -i
         Prompt after any show-on-install text files are printed. Cannot be
         combined with --quiet.
+
+    --stub, -s
+        If specified, also write an uninstall stub in C:\System\Install\.
 
     --verbose, -v
         When listing the SIS file, print extra debug information.
@@ -104,7 +113,7 @@ Options:
             iohandler.setConfig("locale", args.language)
         end
 
-        sis.installSis(data, iohandler, args.verbose)
+        sis.installSis(path_basename(args.filename), data, iohandler, args.stub, args.verbose)
     else
         local sisfile = sis.parseSisFile(data, args.verbose)
         if args.json then

--- a/src/dumpsis.lua
+++ b/src/dumpsis.lua
@@ -46,9 +46,10 @@ function main()
         language = string, l = "language",
         stub = true, s = "stub",
         help = true, h = "help",
+        uninstall = true, u = "uninstall",
     })
 
-    if args.help or args.filename == nil then
+    if args.help or args.filename == nil or (args.uninstall and args.dest == nil) then
         print([[
 Syntax: dumpsis.lua [options] <filename> [<output>]
 
@@ -82,6 +83,10 @@ Options:
 
     --verbose, -v
         When listing the SIS file, print extra debug information.
+
+    --uninstall, -u
+        Uninstall the files referenced by the sis <filename> from <output>.
+        Requires that the SIS was installed with the --stub option.
 ]])
         os.exit(true)
     end
@@ -102,6 +107,13 @@ Options:
     if args.dest then
         local iohandler = require("defaultiohandler")
         iohandler.fsmap("C:\\", path_join(args.dest, ""))
+
+        if args.uninstall then
+            local sisfile = sis.parseSisFile(data)
+            sis.uninstallSis(nil, sisfile.uid, iohandler)
+            return
+        end
+
         if args.interactive then
             setTerminalCharMode(true)
             iohandler.sisInstallQuery = sisInstallQueryInteractive

--- a/src/init.lua
+++ b/src/init.lua
@@ -458,6 +458,8 @@ function dump(...)
     return dump(...)
 end
 
+textReplacementsMatch = "[\x06\x07\x0a\x0b\x10]"
+
 textReplacements = {
     [KParagraphDelimiterStr] = "\n\n",
     [KLineBreakStr] = "\n",

--- a/src/opl.lua
+++ b/src/opl.lua
@@ -1004,7 +1004,7 @@ function CLS()
 end
 
 function PRINT(str)
-    local handlerPrint = runtime:iohandler().print
+    local handlerPrint = runtime:iohandler().iohPrint
     if handlerPrint then
         handlerPrint(str)
         return

--- a/src/recognizer.lua
+++ b/src/recognizer.lua
@@ -120,7 +120,7 @@ function recognize(data, verbose)
         local sis = require("sis")
         local info = sis.parseSisFile(data)
         if info then
-            info = sis.makeManifest(info, true)
+            info = sis.makeManifest(info)
             info.files = nil
         end
         return info
@@ -148,7 +148,7 @@ function getOplText(data)
             local len, pos = readCardinality(data, pos)
             -- 06 means "new paragraph" in TextEd land... everything else likely
             -- to appear in an OPL script is ASCII
-            local text = data:sub(pos, pos + len - 1):gsub("[\x06\x10]", textReplacements)
+            local text = data:sub(pos, pos + len - 1):gsub(textReplacementsMatch, textReplacements)
             return text
         else
             pos = pos + 4 -- Skip over offset of section we don't care about

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -1466,7 +1466,7 @@ function runOpo(fileName, procName, iohandler, verbose)
 end
 
 function installSis(filename, data, iohandler)
-    require("sis").installSis(filename, data, iohandler, true, false)
+    return require("sis").installSis(filename, data, iohandler, true, false)
 end
 
 return _ENV

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -1469,4 +1469,10 @@ function installSis(filename, data, iohandler)
     return require("sis").installSis(filename, data, iohandler, true, false)
 end
 
+function uninstallSis(stubList, uid, iohandler)
+    local sis = require("sis")
+    local stubMap = sis.stubArrayToUidMap(stubList)
+    sis.uninstallSis(stubMap, uid, iohandler)
+end
+
 return _ENV

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -1466,29 +1466,7 @@ function runOpo(fileName, procName, iohandler, verbose)
 end
 
 function installSis(data, iohandler)
-    local sis = require("sis")
-    local sisfile = sis.parseSisFile(data, false)
-
-    local langIdx = sis.getBestLangIdx(sisfile.langs)
-
-    for _, file in ipairs(sisfile.files) do
-        if file.type == sis.FileType.File then
-            local path = file.dest:gsub("^.:\\", "C:\\")
-            local dir = oplpath.dirname(path)
-            if iohandler.fsop("stat", dir) == nil then
-                local err = iohandler.fsop("mkdir", dir)
-                assert(err == KErrNone, "Failed to create dir "..dir)
-            end
-            local data = file.data
-            if not data then
-                data = file.langData[langIdx]
-            end
-            local err = iohandler.fsop("write", path, data)
-            assert(err == KErrNone, "Failed to write to "..path)
-        elseif file.type == sis.FileType.SisComponent then
-            installSis(file.data, iohandler)
-        end
-    end
+    require("sis").installSis(data, iohandler, false)
 end
 
 return _ENV

--- a/src/runtime.lua
+++ b/src/runtime.lua
@@ -1465,8 +1465,8 @@ function runOpo(fileName, procName, iohandler, verbose)
     end
 end
 
-function installSis(data, iohandler)
-    require("sis").installSis(data, iohandler, false)
+function installSis(filename, data, iohandler)
+    require("sis").installSis(filename, data, iohandler, true, false)
 end
 
 return _ENV

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -617,7 +617,7 @@ function getStubs(iohandler)
                 table.insert(result, { path = path, contents = contents })
             end
         end
-    else
+    elseif result == nil then
         return nil, err
     end
     return stubArrayToUidMap(result)

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -452,7 +452,11 @@ function installSis(filename, data, iohandler, includeStub, verbose, stubs)
         end
     end
     if stubs == nil then
-        stubs = getStubs(iohandler)
+        local err
+        stubs, err = getStubs(iohandler)
+        if stubs == nil then
+            return failInstall(nil, "epocerr", err)
+        end
     end
     local existing = stubs[sisfile.uid]
     local ret = iohandler.sisInstallBegin(callbackContext, hasDriveChoice, existing and makeManifest(existing))
@@ -614,7 +618,7 @@ function getStubs(iohandler)
             end
         end
     else
-        assert(result, err)
+        return nil, err
     end
     return stubArrayToUidMap(result)
 end

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -455,7 +455,7 @@ function installSis(filename, data, iohandler, includeStub, verbose, stubs)
         stubs = getStubs(iohandler)
     end
     local existing = stubs[sisfile.uid]
-    local ret = iohandler.sisInstallBegin(callbackContext, hasDriveChoice, existing)
+    local ret = iohandler.sisInstallBegin(callbackContext, hasDriveChoice, existing and makeManifest(existing))
 
     if ret.type == "skip" then
         return nil -- No error

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -386,8 +386,16 @@ end
 function installSis(data, iohandler, verbose)
     local sisfile = parseSisFile(data, verbose)
 
-    local preferredLang = Locales[iohandler.getConfig("locale")]
-    assert(preferredLang, "Bad locale config??")
+    local preferredLang = nil
+    if #sisfile.langs > 1 then
+        local preferredLangName = iohandler.sisInstallGetLanguage(sisfile.langs)
+        if preferredLangName then
+            preferredLang = assert(Locales[preferredLangName], "Bad result from sisInstallGetLanguage?")
+        else
+            -- Nil means abort
+            return
+        end
+    end
 
     local langIdx = getBestLangIdx(sisfile.langs, preferredLang)
     local skipNext = false

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -48,10 +48,10 @@ FileType = enum {
 }
 
 FileTextDetails = enum {
-    Continue = 0,
-    Skip = 1,
-    Abort = 2,
-    Exit = 3,
+    continue = 0,
+    skip = 1,
+    abort = 2,
+    exit = 3,
 }
 
 -- Codes from https://thoukydides.github.io/riscos-psifs/sis.html mapped into
@@ -517,7 +517,7 @@ function installSis(filename, data, iohandler, includeStub, verbose)
             assert(queryType, "Unknown FileText details")
             local shouldContinue = iohandler.sisInstallQuery(text, queryType)
             if not shouldContinue then
-                if queryType == FileTextDetails.Skip then
+                if queryType == "skip" then
                     skipNext = true
                 else
                     return failInstall(i, "usercancel")

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -356,7 +356,7 @@ function makeManifest(sisfile, singleLanguage, includeFiles)
     local result = {
         type = "sis",
         name = includeLangs and json.Dict(langListToLocaleMap(sisfile.langs, sisfile.name)) or sisfile.name[langIdx],
-        version = string.format("%d.%02d", sisfile.version[1], sisfile.version[2]),
+        version = { major = sisfile.version[1], minor = sisfile.version[2] },
         uid = sisfile.uid,
         languages = {},
         drive = sisfile.installedDrive, -- will be nil for non-stubs

--- a/src/sis.lua
+++ b/src/sis.lua
@@ -388,7 +388,11 @@ function installSis(data, iohandler, verbose)
 
     local preferredLang = nil
     if #sisfile.langs > 1 then
-        local preferredLangName = iohandler.sisInstallGetLanguage(sisfile.langs)
+        local candidateLanguages = {}
+        for i, langId in ipairs(sisfile.langs) do
+            candidateLanguages[i] = assert(Locales[langId], "Bad langId "..tostring(langId))
+        end
+        local preferredLangName = iohandler.sisInstallGetLanguage(candidateLanguages)
         if preferredLangName then
             preferredLang = assert(Locales[preferredLangName], "Bad result from sisInstallGetLanguage?")
         else
@@ -399,7 +403,9 @@ function installSis(data, iohandler, verbose)
 
     local langIdx = getBestLangIdx(sisfile.langs, preferredLang)
     local skipNext = false
-    for _, file in ipairs(sisfile.files) do
+    -- You're supposed to iterate the files list backwards when installing
+    for i = #sisfile.files, 1, -1 do
+        local file = sisfile.files[i]
         if skipNext then
             printf("Skipping file %s\n", file.dest)
             skipNext = false

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -624,6 +624,9 @@ public protocol SisInstallIoHandler: FileSystemIoHandler {
     // Return true to continue, false if user selected "No"
     func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool
 
+    // Return nil to abort install, otherwise result should be one of languages
+    func sisInstallGetLanguage(_ languages: [String]) -> String?
+
 }
 
 public protocol OpoIoHandler: FileSystemIoHandler {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -620,10 +620,10 @@ public protocol FileSystemIoHandler {
 }
 
 public enum InstallerQueryType: String {
-    case Continue // "Continue" button only
-    case Skip // "Yes"/"No" buttons, next install file skipped on "No"
-    case Abort // "Yes"/"No" buttons, abort install on "No"
-    case Exit // Same as abort but also do cleanup (?)
+    case `continue` // "Continue" button only
+    case skip // "Yes"/"No" buttons, next install file skipped on "No"
+    case abort // "Yes"/"No" buttons, abort install on "No"
+    case exit // Same as abort but also do cleanup (?)
 }
 
 public struct SisFile: Codable {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -446,6 +446,12 @@ public struct Fs {
         public let size: UInt64
         public let lastModified: Date
         public let isDirectory: Bool
+
+        public init(size: UInt64, lastModified: Date, isDirectory: Bool) {
+            self.size = size
+            self.lastModified = lastModified
+            self.isDirectory = isDirectory
+        }
     }
 
     public enum Err: Int {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -631,6 +631,11 @@ public struct Sis {
     public struct Stub: Codable {
         public let path: String
         public let contents: Data
+
+        public init(path: String, contents: Data) {
+            self.path = path
+            self.contents = contents
+        }
     }
 
     public enum GetStubsResult {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -456,6 +456,7 @@ public struct Fs {
 
     public enum Err: Int {
         case none = 0
+        case general = -1
         case inUse = -9
         case notFound = -33
         case alreadyExists = -32

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -659,9 +659,9 @@ public struct Sis {
     }
 
     public struct BeginContext: Codable {
-        let driveRequired: Bool
-        let replacing: Sis.Installation?
-        let isRoot: Bool
+        public let driveRequired: Bool
+        public let replacing: Sis.Installation?
+        public let isRoot: Bool
     }
 
     public enum BeginResult {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -428,13 +428,13 @@ extension Graphics.GreyMode {
 public struct Fs {
     public struct Operation {
         public enum OpType {
-            case delete // return none, notFound, accessDenied if readonly, notReady
-            case mkdir // return none, alreadyExists, accessDenied if readonly, notReady
-            case rmdir // return none, notFound, inUse if it isn't empty, pathNotFound if it's not a dir, accessDenied if readonly, notReady
-            case write(Data) // return none, accessDenied if readonly, notReady
-            case read // return none, notFound, notReady
+            case delete // return .success, notFound, accessDenied if readonly, notReady
+            case mkdir // return .success, alreadyExists, accessDenied if readonly, notReady
+            case rmdir // return .success, notFound, inUse if it isn't empty, pathNotFound if it's not a dir, accessDenied if readonly, notReady
+            case write(Data) // return .success, accessDenied if readonly, notReady
+            case read // return .data() or notFound, notReady
             case dir // return .strings(paths)
-            case rename(String) // return none, notFound, accessDenied if readonly, notReady, alreadyExists
+            case rename(String) // return .success, notFound, accessDenied if readonly, notReady, alreadyExists
             case stat // return stat, or notFound or notReady
             case disks // return .strings(diskList)
         }
@@ -455,7 +455,6 @@ public struct Fs {
     }
 
     public enum Err: Int {
-        case none = 0
         case general = -1
         case inUse = -9
         case notFound = -33
@@ -466,6 +465,7 @@ public struct Fs {
     }
 
     public enum Result {
+        case success
         case err(Err)
         case data(Data)
         case stat(Stat)

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -621,17 +621,27 @@ public protocol FileSystemIoHandler {
 }
 
 public struct Sis {
+    public struct Version: Codable /* also Comparable, CustomStringConvertible */ {
+        public let major: Int
+        public let minor: Int
+
+        public init(major: Int, minor: Int) {
+            self.major = major
+            self.minor = minor
+        }
+    }
+
     public struct File: Codable {
         public let name: [String: String]
         public let uid: UInt32
-        public let version: String
+        public let version: Version
         public let languages: [String]
     }
 
     public struct Installation: Codable {
         public let name: String
         public let uid: UInt32
-        public let version: String
+        public let version: Version
         public let language: String
         public let drive: String
     }

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -634,6 +634,8 @@ public protocol SisInstallIoHandler: FileSystemIoHandler {
     // Return nil to abort install, otherwise result should be one of languages
     func sisInstallGetLanguage(_ languages: [String]) -> String?
 
+    // Return nil to abort install. Otherwise should be a single character string, eg "C"
+    func sisInstallGetDrive() -> String?
 }
 
 public protocol OpoIoHandler: FileSystemIoHandler {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -636,14 +636,14 @@ public struct SisFile: Codable {
 
 public enum SisInstallError: Error, Equatable {
     case userCancelled
-    case epocError(Int, String)
+    case epocError(Int32, String?)
     case internalError(String)
 }
 
 public enum SisInstallBeginResult {
     case skipInstall // Not an error
     case userCancelled
-    case epocError(Int)
+    case epocError(Int32)
     case install(String, String) // language and drive
 }
 

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -628,6 +628,14 @@ public struct Sis {
         public let languages: [String]
     }
 
+    public struct Installation: Codable {
+        public let name: String
+        public let uid: UInt32
+        public let version: String
+        public let language: String
+        public let drive: String
+    }
+
     public struct Stub: Codable {
         public let path: String
         public let contents: Data
@@ -650,6 +658,12 @@ public struct Sis {
         case internalError(String)
     }
 
+    public struct BeginContext: Codable {
+        let driveRequired: Bool
+        let replacing: Sis.Installation?
+        let isRoot: Bool
+    }
+
     public enum BeginResult {
         case skipInstall // Not an error
         case userCancelled
@@ -669,7 +683,7 @@ public protocol SisInstallIoHandler: FileSystemIoHandler {
 
     func sisGetStubs() -> Sis.GetStubsResult
 
-    func sisInstallBegin(sis: Sis.File, driveRequired: Bool, replacing: Sis.File?) -> Sis.BeginResult
+    func sisInstallBegin(sis: Sis.File, context: Sis.BeginContext) -> Sis.BeginResult
 
     // Return true to continue, false if user selected "No"
     func sisInstallQuery(sis: Sis.File, text: String, type: Sis.QueryType) -> Bool

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -649,16 +649,16 @@ public enum SisInstallBeginResult {
 
 public protocol SisInstallIoHandler: FileSystemIoHandler {
 
-    func sisInstallBegin(info: SisFile, driveRequired: Bool) -> SisInstallBeginResult
+    func sisInstallBegin(sis: SisFile, driveRequired: Bool) -> SisInstallBeginResult
 
     // Return true to continue, false if user selected "No"
-    func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool
+    func sisInstallQuery(sis: SisFile, text: String, type: InstallerQueryType) -> Bool
 
     // Called to indicate that an error occurred and the installation will now roll back. Return false to indicate
     // rollback is unnecessary (because for eg, the native code will take care of it).
-    func sisInstallRollback() -> Bool
+    func sisInstallRollback(sis: SisFile) -> Bool
 
-    func sisInstallComplete()
+    func sisInstallComplete(sis: SisFile)
 }
 
 public protocol OpoIoHandler: FileSystemIoHandler {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -626,7 +626,17 @@ public enum InstallerQueryType: String {
     case Exit // Same as abort but also do cleanup (?)
 }
 
+public struct SisFile: Codable {
+    public let name: [String: String]
+    public let uid: UInt32
+    public let version: String
+    public let languages: [String]
+}
+
 public protocol SisInstallIoHandler: FileSystemIoHandler {
+
+    // Return false to not install this SIS (without erroring)
+    func sisInstallBegin(info: SisFile) -> Bool
 
     // Return true to continue, false if user selected "No"
     func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool
@@ -636,6 +646,8 @@ public protocol SisInstallIoHandler: FileSystemIoHandler {
 
     // Return nil to abort install. Otherwise should be a single character string, eg "C"
     func sisInstallGetDrive() -> String?
+
+    func sisInstallComplete()
 }
 
 public protocol OpoIoHandler: FileSystemIoHandler {

--- a/swift/OpoIoHandler.swift
+++ b/swift/OpoIoHandler.swift
@@ -589,6 +589,7 @@ extension Async.KeyPressEvent {
 
 public enum ConfigName: String, CaseIterable {
     case clockFormat // 0: analog, 1: digital
+    case locale // eg "en_GB"
 }
 
 public struct TextFieldInfo: Codable {
@@ -611,9 +612,17 @@ public protocol FileSystemIoHandler {
 
 }
 
+public enum InstallerQueryType: String {
+    case Continue // "Continue" button only
+    case Skip // "Yes"/"No" buttons, next install file skipped on "No"
+    case Abort // "Yes"/"No" buttons, abort install on "No"
+    case Exit // Same as abort but also do cleanup (?)
+}
+
 public protocol SisInstallIoHandler: FileSystemIoHandler {
 
-    // probably some extra stuff for prompting the user
+    // Return true to continue, false if user selected "No"
+    func sisInstallQuery(text: String, type: InstallerQueryType) -> Bool
 
 }
 

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -416,16 +416,17 @@ public class PsiLuaEnv {
         guard let data = FileManager.default.contents(atPath: path) else {
             throw LuaArgumentError(errorString: "Couldn't read \(path)")
         }
-        try installSisFile(data: data, handler: handler)
+        try installSisFile(path: path, data: data, handler: handler)
     }
 
-    public func installSisFile(data: Data, handler: SisInstallIoHandler) throws {
+    public func installSisFile(path: String? = nil, data: Data, handler: SisInstallIoHandler) throws {
         let top = L.gettop()
         defer {
             L.settop(top)
         }
         require("runtime")
         L.rawget(-1, utf8Key: "installSis")
+        L.push(path)
         L.push(data)
         makeSisInstallIoHandlerBridge(handler)
         try L.pcall(nargs: 2, nret: 0)

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -700,3 +700,19 @@ extension Sis.InstallError: Pushable {
         try! state.push(encodable: self)
     }
 }
+
+extension Sis.Version: Comparable {
+    public static func < (lhs: Sis.Version, rhs: Sis.Version) -> Bool {
+        return lhs.major < rhs.major || (lhs.major == rhs.major && lhs.minor < rhs.minor)
+    }
+
+    public static func == (lhs: Sis.Version, rhs: Sis.Version) -> Bool {
+        return lhs.major == rhs.major && lhs.minor == rhs.minor
+    }
+}
+
+extension Sis.Version: CustomStringConvertible {
+    public var description: String {
+        return String(format: "%d.%02d", major, minor)
+    }
+}

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -437,6 +437,7 @@ public class PsiLuaEnv {
         L.push(Wrapper<SisInstallIoHandler>(value: handler))
         let fns: [String: lua_CFunction] = [
             "sisInstallQuery": { L in return autoreleasepool { return PsiLuaEnv.sisInstallQuery(L) } },
+            "sisInstallGetLanguage": { L in return autoreleasepool { return PsiLuaEnv.sisInstallGetLanguage(L) } },
         ]
         L.setfuncs(fns, nup: 1)
     }
@@ -455,6 +456,18 @@ public class PsiLuaEnv {
             return 0
         }
         let result = iohandler.sisInstallQuery(text: text, type: queryType)
+        L.push(result)
+        return 1
+    }
+
+    internal static let sisInstallGetLanguage: lua_CFunction = { (L: LuaState!) -> CInt in
+        let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
+        let iohandler = wrapper.value
+        guard let langs: [String] = L.tovalue(1) else {
+            print("Bad languages!")
+            return 0
+        }
+        let result = iohandler.sisInstallGetLanguage(langs)
         L.push(result)
         return 1
     }

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -192,12 +192,16 @@ public class PsiLuaEnv {
     }
 
     public func recognize(path: String) -> FileType {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            return .unknown
+        }
+        return self.recognize(data: data)
+    }
+
+    public func recognize(data: Data) -> FileType {
         let top = L.gettop()
         defer {
             L.settop(top)
-        }
-        guard let data = FileManager.default.contents(atPath: path) else {
-            return .unknown
         }
         require("recognizer")
         L.rawget(-1, key: "recognize")
@@ -213,12 +217,16 @@ public class PsiLuaEnv {
     }
 
     public func getFileInfo(path: String) -> FileInfo {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            return .unknown
+        }
+        return getFileInfo(data: data)
+    }
+
+    public func getFileInfo(data: Data) -> FileInfo {
         let top = L.gettop()
         defer {
             L.settop(top)
-        }
-        guard let data = FileManager.default.contents(atPath: path) else {
-            return .unknown
         }
         require("recognizer")
         L.rawget(-1, key: "recognize")

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -484,7 +484,7 @@ public class PsiLuaEnv {
             return 0
         }
         let driveRequired = L.toboolean(2)
-        let result = iohandler.sisInstallBegin(info: info, driveRequired: driveRequired)
+        let result = iohandler.sisInstallBegin(sis: info, driveRequired: driveRequired)
         L.push(result)
         return 1
     }
@@ -492,7 +492,11 @@ public class PsiLuaEnv {
     internal static let sisInstallRollback: lua_CFunction = { (L: LuaState!) -> CInt in
         let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
         let iohandler = wrapper.value
-        let result = iohandler.sisInstallRollback()
+        guard let info: SisFile = L.todecodable(1) else {
+            print("Bad SIS info!")
+            return 0
+        }
+        let result = iohandler.sisInstallRollback(sis: info)
         L.push(result)
         return 1
     }
@@ -500,24 +504,32 @@ public class PsiLuaEnv {
     internal static let sisInstallComplete: lua_CFunction = { (L: LuaState!) -> CInt in
         let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
         let iohandler = wrapper.value
-        iohandler.sisInstallComplete()
+        guard let info: SisFile = L.todecodable(1) else {
+            print("Bad SIS info!")
+            return 0
+        }
+        iohandler.sisInstallComplete(sis: info)
         return 0
     }
 
     internal static let sisInstallQuery: lua_CFunction = { (L: LuaState!) -> CInt in
         let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
         let iohandler = wrapper.value
-        guard let text = L.tostring(1, encoding: .utf8) else {
+        guard let info: SisFile = L.todecodable(1) else {
+            print("Bad SIS info!")
+            return 0
+        }
+        guard let text = L.tostring(2, encoding: .utf8) else {
             print("Bad text!")
             return 0
         }
-        guard let queryString = L.tostring(2),
+        guard let queryString = L.tostring(3),
               let queryType = InstallerQueryType(rawValue: queryString)
         else {
-            print("Unknown queryType \(L.tostring(2, convert: true)!)")
+            print("Unknown queryType \(L.tostring(3, convert: true)!)")
             return 0
         }
-        let result = iohandler.sisInstallQuery(text: text, type: queryType)
+        let result = iohandler.sisInstallQuery(sis: info, text: text, type: queryType)
         L.push(result)
         return 1
     }

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -598,10 +598,6 @@ extension SisInstallError: CustomStringConvertible {
     }
 }
 
-extension SisInstallError: LocalizedError {
-    public var errorDescription: String? { return self.description }
-}
-
 extension SisInstallError: Codable {
 
     private enum CodingKeys: String, CodingKey {

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -405,17 +405,21 @@ public class PsiLuaEnv {
     }
 
     public func installSisFile(path: String, handler: SisInstallIoHandler) throws {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            throw LuaArgumentError(errorString: "Couldn't read \(path)")
+        }
+        try installSisFile(data: data, handler: handler)
+    }
+
+    public func installSisFile(data: Data, handler: SisInstallIoHandler) throws {
         let top = L.gettop()
         defer {
             L.settop(top)
         }
-        guard let data = FileManager.default.contents(atPath: path) else {
-            throw LuaArgumentError(errorString: "Couldn't read \(path)")
-        }
         require("runtime")
         L.rawget(-1, utf8Key: "installSis")
         L.push(data)
-        makeFsIoHandlerBridge(handler)
+        makeSisInstallIoHandlerBridge(handler)
         try L.pcall(nargs: 2, nret: 0)
     }
 

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -429,7 +429,7 @@ public class PsiLuaEnv {
         L.push(path)
         L.push(data)
         makeSisInstallIoHandlerBridge(handler)
-        try L.pcall(nargs: 2, nret: 0)
+        try L.pcall(nargs: 3, nret: 0)
     }
 
     internal func makeFsIoHandlerBridge(_ handler: FileSystemIoHandler) {

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -514,9 +514,11 @@ public class PsiLuaEnv {
             print("Bad SIS info!")
             return 0
         }
-        let driveRequired = L.toboolean(2)
-        let replacing: Sis.File? = L.todecodable(3)
-        let result = iohandler.sisInstallBegin(sis: info, driveRequired: driveRequired, replacing: replacing)
+        guard let context: Sis.BeginContext = L.todecodable(2) else {
+            print("Bad BeginContext!")
+            return 0
+        }
+        let result = iohandler.sisInstallBegin(sis: info, context: context)
         L.push(result)
         return 1
     }

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -445,7 +445,7 @@ public class PsiLuaEnv {
     internal static let sisInstallQuery: lua_CFunction = { (L: LuaState!) -> CInt in
         let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
         let iohandler = wrapper.value
-        guard let text = L.tostring(1) else {
+        guard let text = L.tostring(1, encoding: .utf8) else {
             print("Bad text!")
             return 0
         }

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -447,6 +447,7 @@ public class PsiLuaEnv {
         let fns: [String: lua_CFunction] = [
             "sisInstallQuery": { L in return autoreleasepool { return PsiLuaEnv.sisInstallQuery(L) } },
             "sisInstallGetLanguage": { L in return autoreleasepool { return PsiLuaEnv.sisInstallGetLanguage(L) } },
+            "sisInstallGetDrive": { L in return autoreleasepool { return PsiLuaEnv.sisInstallGetDrive(L) } },
         ]
         L.setfuncs(fns, nup: 1)
     }
@@ -477,6 +478,14 @@ public class PsiLuaEnv {
             return 0
         }
         let result = iohandler.sisInstallGetLanguage(langs)
+        L.push(result)
+        return 1
+    }
+
+    internal static let sisInstallGetDrive: lua_CFunction = { (L: LuaState!) -> CInt in
+        let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
+        let iohandler = wrapper.value
+        let result = iohandler.sisInstallGetDrive()
         L.push(result)
         return 1
     }

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -375,10 +375,11 @@ public class PsiLuaEnv {
 
         let result = iohandler.fsop(Fs.Operation(path: path, type: op))
         switch (result) {
+        case .success:
+            L.push(0)
+            return 1
         case .err(let err):
-            if err != .none {
-                print("Error \(err) for cmd \(op) path \(path)")
-            }
+            print("Error \(err) for cmd \(op) path \(path)")
             if cmd == "read" || cmd == "dir" || cmd == "stat" {
                 L.pushnil()
                 L.push(err.rawValue)

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -592,7 +592,7 @@ extension SisInstallError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .userCancelled: return "SisInstallError.userCancelled"
-        case .epocError(let err, let path): return "SisInstallError.epocError(\(err), \(path))"
+        case .epocError(let err, let context): return "SisInstallError.epocError(\(err), \(context ?? "''"))"
         case .internalError(let err): return "SisInstallError.internalError(\(err))"
         }
     }
@@ -613,8 +613,8 @@ extension SisInstallError: Codable {
         case "usercancel":
             self = .userCancelled
         case "epocerr":
-            let code: Int = try values.decode(Int.self, forKey: .code)
-            let path = try values.decode(String.self, forKey: .context)
+            let code: Int32 = try values.decode(Int32.self, forKey: .code)
+            let path = try values.decode(String?.self, forKey: .context)
             self = .epocError(code, path)
         case "internal":
             let details = try values.decode(String.self, forKey: .context)
@@ -651,7 +651,7 @@ extension SisInstallBeginResult: Pushable {
         case .userCancelled:
             L.rawset(-1, key: "type", value: "usercancel")
         case .epocError(let err):
-            L.rawset(-1, key: "type", value: "err")
+            L.rawset(-1, key: "type", value: "epocerr")
             L.rawset(-1, key: "code", value: err)
         case .install(let lang, let drive):
             L.rawset(-1, key: "type", value: "install")


### PR DESCRIPTION
Much of which is internal. Most visible improvements are to the dumpsis.lua command which now:

* allows creation of installation receipts ('stubs')
* can uninstall SIS files
* shows FileText prompts from SIS files that have them