### PR TITLE
fix: Use common SIS file type identifier

### DIFF
--- a/OpoLua/Info.plist
+++ b/OpoLua/Info.plist
@@ -15,7 +15,7 @@
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>org.opolua.sis</string>
+				<string>com.psion.sis</string>
 			</array>
 		</dict>
 	</array>
@@ -102,7 +102,7 @@
 			<key>UTTypeIconFiles</key>
 			<array/>
 			<key>UTTypeIdentifier</key>
-			<string>org.opolua.sis</string>
+			<string>com.psion.sis</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>


### PR DESCRIPTION
This changes the SIS file type identifier from `org.opolua.sis` to a more generic (but invented) `com.psion.sis` in an attempt to establish an identifier that can be shared between different apps. In the near term, the goal is to come up with an identifier that can be shared with Reconnect.