### PR TITLE
docs[website]: Move the privacy policy link into the footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,4 +1,9 @@
-<div class="footer">
+<footer>
     <p class="copyright">Copyright © 2021-2025 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
     <p>Psion, OPL, and EPOC remain the trademarks of their respective owners. OpoLua is in no way affiliated with those owners.<p>
-</div>
+    <nav>
+        <ul>
+            <li><a href="/privacy-policy/">Privacy Policy</a></li>
+        </ul>
+    </nav>
+</footer>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -3,7 +3,6 @@
     <li><a href="/screenshots">Screenshots</a></li>
     <li><a href="/status">Status</a></li>
     <li><a href="/faq">FAQ</a></li>
-    <li><a href="/release-notes">Release Notes</a></li>
-    <li><a href="/privacy-policy/">Privacy Policy</a></li>
+    <li><a href="/release-notes">Releases</a></li>
     <li><a href="https://github.com/inseven/opolua" target="_blank">GitHub</a></li>
 </ul>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -56,7 +56,7 @@ a:hover {
 }
 
 ul.navigation a,
-.footer a {
+footer a {
     text-decoration: none;
 }
 
@@ -139,27 +139,38 @@ th, td {
     font-size: 1.3em;
 }
 
-.footer {
+footer {
     max-width: var(--content-width);
     margin: auto;
     padding: 2em;
+    font-size: 0.8em;
+    text-align: center;
 }
 
-.footer p {
+footer p {
     color: var(--secondary-color);
-    text-align: center;
-    font-size: 0.8em;
     margin: 0;
 }
 
-.footer a {
+footer a {
     color: var(--secondary-link-color);
     text-decoration: underline;
     font-weight: 200;
 }
 
-.footer a:hover {
+footer a:hover {
     color: var(--tint-color);
+}
+
+footer nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+footer nav ul li {
+    display: inline;
+    margin-right: 0.4em;
 }
 
 .copyright {


### PR DESCRIPTION
This includes a drive-by fix to rename the 'Release Notes' link in the header to 'Releases'.