### PR TITLE
ci: Deploy website using GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,46 +50,32 @@ jobs:
 
   website-build:
 
-    runs-on: ubuntu-latest
+      needs: [app-build]
 
-    steps:
+      runs-on: ubuntu-latest
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      steps:
 
-    - name: Checkout required submodules
-      run: |
-        git submodule update --init --depth 1 scripts/build-tools
-        git submodule update --init --depth 1 scripts/changes
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.9"
+      - name: Checkout required submodules
+        run: |
+          git submodule update --init --depth 1 scripts/build-tools
+          git submodule update --init --depth 1 scripts/changes
 
-    - name: Install pipenv
-      run: |
-        python -m pip install --upgrade pipenv wheel
+      - name: Install the tool dependencies
+        uses: jdx/mise-action@v2
 
-    - uses: jdx/mise-action@v2
-      with:
-        install: true
-        cache: true
+      - name: Install dependencies
+        run: scripts/install-dependencies.sh
 
-    - name: Install dependencies
-      run: scripts/install-dependencies.sh
+      - name: Build website
+        run: |
+          scripts/build-website.sh
+          chmod -v -R +rX "_site/"
 
-    - name: Update release notes
-      run: |
-        scripts/update-release-notes.sh
-
-    - name: Commit documentation
-      uses: stefanzweifel/git-auto-commit-action@v5
-      id: auto-commit
-      with:
-        branch: documentation
-        create_branch: true
-        push_options: --force
-        commit_message: "docs: Update release notes"
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-_site
 .build
 .jekyll-cache
 .local
 .swiftpm
+/_site
 /docs/releases
 build

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,7 @@ url: ""
 
 plugins:
   - jekyll-feed
+destination: ../_site
 
 defaults:
   - values:

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright (c) 2021-2025 Jason Morley, Tom Sutcliffe
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+set -o pipefail
+set -x
+set -u
+
+SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+ROOT_DIRECTORY="$SCRIPTS_DIRECTORY/.."
+WEBSITE_DIRECTORY="$ROOT_DIRECTORY/docs"
+WEBSITE_SIMULATOR_DIRECTORY="$ROOT_DIRECTORY/docs/simulator"
+SIMULATOR_WEB_DIRECTORY="$ROOT_DIRECTORY/simulator/web"
+
+RELEASE_NOTES_TEMPLATE_PATH="$SCRIPTS_DIRECTORY/release-notes.md"
+HISTORY_PATH="$SCRIPTS_DIRECTORY/history.yaml"
+RELEASE_NOTES_DIRECTORY="$ROOT_DIRECTORY/docs/release-notes"
+RELEASE_NOTES_PATH="$RELEASE_NOTES_DIRECTORY/index.markdown"
+
+source "$SCRIPTS_DIRECTORY/environment.sh"
+
+cd "$ROOT_DIRECTORY"
+if [ -d "$RELEASE_NOTES_DIRECTORY" ]; then
+    rm -r "$RELEASE_NOTES_DIRECTORY"
+fi
+"$SCRIPTS_DIRECTORY/update-release-notes.sh"
+
+# Install the Jekyll dependencies.
+export GEM_HOME="${ROOT_DIRECTORY}/.local/ruby"
+mkdir -p "$GEM_HOME"
+export PATH="${GEM_HOME}/bin":$PATH
+gem install bundler
+cd "${WEBSITE_DIRECTORY}"
+bundle install
+
+# Build the website.
+cd "${WEBSITE_DIRECTORY}"
+bundle exec jekyll build


### PR DESCRIPTION
This change switches to using the built-in GitHub Actions support for deploying sites (instead of checking changes back into a custom git branch).