### PR TITLE
fix: recognizer.lua should handle SIBO OPAs without icons

### DIFF
--- a/src/recognizer.lua
+++ b/src/recognizer.lua
@@ -29,7 +29,15 @@ function recognize(data, verbose)
     if siboHeader == "ALawSoundFile**\0" then
         return { type = "sound", data = require("sound").parseWveFile(data) }
     elseif siboHeader == "OPLObjectFile**\0" then
-        return require("aif").parseAif(data)
+        local info = require("aif").parseAif(data)
+        if info then
+            return info
+        else
+            -- parseAif could return nil if there's no actual icons
+           return { type = "opo", era = "sibo", uid3 = 0 }
+       end
+    elseif siboHeader == "ImageFileType**\0" then
+        return { type = "nativebin", era = "sibo" }
     elseif data:sub(1, 4) == "PIC\xDC" then
         return { type = "mbm", bitmaps = getMbmBitmaps(data) }
     end
@@ -114,6 +122,10 @@ function recognize(data, verbose)
 
     if uid1 == KPermanentFileStoreLayoutUid then
         return { type = "database" }
+    end
+
+    if uid1 == KDynamicLibraryUid then
+        return { type = "nativebin", era = "er5" }
     end
 
     if (uid2 == KUidAppDllDoc8 or uid2 == KUidSisFileEr6) and uid3 == KUidInstallApp then

--- a/swift/PsiLuaEnv.swift
+++ b/swift/PsiLuaEnv.swift
@@ -153,6 +153,10 @@ public class PsiLuaEnv {
         public let era: AppEra
     }
 
+    public struct NativeBinary : Codable {
+        public let era: AppEra
+    }
+
     public struct ResourceFile: Codable {
         public let idOffset: UInt32?
     }
@@ -162,6 +166,7 @@ public class PsiLuaEnv {
         case aif
         case database
         case mbm
+        case nativebin
         case opl
         case opa
         case opo
@@ -176,6 +181,7 @@ public class PsiLuaEnv {
         case aif(AppInfo)
         case database
         case mbm(MbmFile)
+        case nativebin(NativeBinary)
         case opl(OplFile)
         case opa(OpaFile)
         case opo(OpoFile)
@@ -263,6 +269,10 @@ public class PsiLuaEnv {
         case .opo:
             if let info: OpoFile = L.todecodable(-1) {
                 return .opo(info)
+            }
+        case .nativebin:
+            if let info: NativeBinary = L.todecodable(-1) {
+                return .nativebin(info)
             }
         case .resource:
             if let info: ResourceFile = L.todecodable(-1) {


### PR DESCRIPTION
As well as native binaries