### PR TITLE
fix(qt): Store the the SIS download URL in the manifest, if possible

### DIFF
--- a/qt/mainwindow.h
+++ b/qt/mainwindow.h
@@ -46,15 +46,16 @@ private slots:
     void forceClose();
     void startedRunning(const OplAppInfo& info);
     void runComplete(const QString& errMsg, const QString& errDetail);
-    void installationComplete();
+    void installationComplete(const QString& sisPath);
     void updateRecents(const QStringList& recentFiles);
     void onSpeedChanged();
 
 private:
     void setDevice(QAction* action, int device);
     void sizeWindowToFitInterpreter();
+    QString getSourceUrlForPath(const QString& path);
     void applyManifest();
-    void updateManifest();
+    void updateManifest(const QString& sourceUrl = QString());
     void doInstallSis(const QString& file);
 
 private:

--- a/qt/oplruntime.cpp
+++ b/qt/oplruntime.cpp
@@ -533,7 +533,7 @@ void OplRuntime::runInstaller(const QString& file, const QString& displayPath)
     pushValue(L, file);
     pushValue(L, QString("I:\\" + QFileInfo(file).fileName()));
     pushValue(L, displayPath);
-    mRunNextFn = [this]() {
+    mRunNextFn = [this, file]() {
         mFs->removeMapping('I');
         if (lua_type(L, -1) != LUA_TTABLE) {
             emit runComplete(QString(), QString());
@@ -541,7 +541,7 @@ void OplRuntime::runInstaller(const QString& file, const QString& displayPath)
         }
         auto launch = to_string(L, -1, "launch");
         lua_pop(L, 1);
-        emit installationComplete();
+        emit installationComplete(file);
         if (!launch.isEmpty()) {
             pushRunParams(launch);
             startThread();

--- a/qt/oplruntime.h
+++ b/qt/oplruntime.h
@@ -116,7 +116,7 @@ signals:
     void startedRunning(const QString& path);
     void titleChanged(const QString& title);
     void runComplete(const QString& errMsg, const QString& errDetail);
-    void installationComplete();
+    void installationComplete(const QString& sisPath);
     void systemClockChanged(bool digital);
     void escapeStateChanged(bool on);
     void speedChanged();


### PR DESCRIPTION
Both macOS and Windows store the URL that a SIS file was downloaded from (or at least, most web browsers follow this convention), so store this in the manifest so we can potentially use it for bug reports later.