### PR TITLE
fix: Don't attempt to reconstruct an MBM when dumpaif-ing a .opa

### DIFF
--- a/src/dumpaif.lua
+++ b/src/dumpaif.lua
@@ -86,7 +86,7 @@ Options:
             end
         end
 
-        if #info.icons > 0 then
+        if #info.icons > 0 and info.era ~= "sibo" then
             local mbmName = string.format("%s_icons.mbm", args.filename)
             writeFile(mbmName, aif.toMbm(info))
         end


### PR DESCRIPTION
Because the bitmaps in a .opa aren't in MBM format in the first place.