### PR TITLE
fix: Fix path mangling when file extension is more than 3 characters

### DIFF
--- a/OpoLua/Extensions/FileManager.swift
+++ b/OpoLua/Extensions/FileManager.swift
@@ -182,14 +182,6 @@ extension FileManager {
                 }
             }
         }
-        if let dot = uncasedName.lastIndex(of: ".") {
-            let suff = uncasedName[uncasedName.index(after: dot)...]
-            if suff.count > 3 {
-                //  Try truncating the extension to 3 chars
-                let newName = String(uncasedName[...dot]) + suff.prefix(3)
-                return try findCorrectCase(in: path, for: newName)
-            }
-        }
         return uncasedName
     }
 

--- a/qt/filesystem.cpp
+++ b/qt/filesystem.cpp
@@ -136,13 +136,6 @@ QString FileSystemIoHandler::getNativePath(const QString& devicePath, bool* writ
                 // Try a case-insensitive match
                 auto map = getEntryListLowerMap(dir);
                 foundEntry = map.value(component.toLower());
-                if (foundEntry.isEmpty()) {
-                    // Epoc seems to have a weird handling of paths ending in a space, in that playing a sound file
-                    // with a path "C:\name.wav " will work (assuming the file is called "name.wav"). Whether that's
-                    // truncating of extensions with more than 3 letters, or simply that spaces on the of paths are
-                    // ignored, I'm not sure.
-                    foundEntry = map.value(component.toLower().trimmed());
-                }
             }
 
             if (foundEntry.isEmpty()) {

--- a/src/opx/system.lua
+++ b/src/opx/system.lua
@@ -381,6 +381,13 @@ function PlaySoundA(stack, runtime) -- 39
     local var = stack:pop():asVariable(DataTypes.ELong)
     local volume = stack:pop() -- not used atm...
     local path = stack:pop()
+
+    if path:match(" $") then
+        -- For some odd reason some programs put a space on the end, and the series 5 will allow it. See
+        -- https://github.com/inseven/opolua/issues/449
+        -- for the mess this caused when 'fixed' at the filesystem level.
+        path = path:sub(1, -2)
+    end
     runtime:PlaySoundA(var, path)
     stack:push(0)
 end


### PR DESCRIPTION
Which indirectly fixes #449 by removing the hack which was causing that issue, and moving it to PlaySoundA which is the only place where the hack seems to actually be needed.