### PR TITLE
refactor: Prefix Software Index structs with `SoftwareIndex`

### DIFF
--- a/OpoLua/View Controllers/BrowserViewController.swift
+++ b/OpoLua/View Controllers/BrowserViewController.swift
@@ -63,7 +63,7 @@ class BrowserViewController: UICollectionViewController {
     ]
 
     @objc func showSoftwareIndex() {
-        let indexViewController = PsionSoftwareIndexViewController { release in
+        let indexViewController = SoftwareIndexViewController { release in
 #if RELEASE
             guard !Self.blockedUIDs.contains(release.uid) else {
                 return false
@@ -127,13 +127,13 @@ extension BrowserViewController: UIDocumentPickerDelegate {
 
 }
 
-extension BrowserViewController: PsionSoftwareIndexViewControllerDelegate {
+extension BrowserViewController: SoftwareIndexViewControllerDelegate {
 
-    func psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: PsionSoftwareIndexViewController) {
+    func psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: SoftwareIndexViewController) {
         psionSoftwareIndexViewController.dismiss(animated: true)
     }
 
-    func psionSoftwareIndexViewController(psionSoftwareIndexViewController: PsionSoftwareIndexViewController,
+    func psionSoftwareIndexViewController(psionSoftwareIndexViewController: SoftwareIndexViewController,
                                           didSelectItem item: SoftwareIndexView.Item) {
         psionSoftwareIndexViewController.dismiss(animated: true) {
             AppDelegate.shared.install(url: item.url, sourceUrl: item.sourceURL)

--- a/PsionSoftwareIndexSwift/Package.swift
+++ b/PsionSoftwareIndexSwift/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     name: "PsionSoftwareIndexSwift",
     platforms: [
         .iOS(.v15),
-        .macOS(.v14),
     ],
     products: [
         .library(

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Model/SoftwareIndexLibraryModel.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Model/SoftwareIndexLibraryModel.swift
@@ -22,17 +22,17 @@ import Combine
 import SwiftUI
 
 /// Callbacks always occur on `MainActor`.
-protocol LibraryModelDelegate: AnyObject {
+protocol SoftwareIndexLibraryModelDelegate: AnyObject {
 
     @MainActor
-    func libraryModelDidCancel(libraryModel: LibraryModel)
+    func libraryModelDidCancel(libraryModel: SoftwareIndexLibraryModel)
 
     @MainActor
-    func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item)
+    func libraryModel(libraryModel: SoftwareIndexLibraryModel, didSelectItem item: SoftwareIndexView.Item)
 
 }
 
-@MainActor class LibraryModel: ObservableObject {
+@MainActor class SoftwareIndexLibraryModel: ObservableObject {
 
     @Published var isLoading: Bool = true
     @Published var programs: [SoftwareIndex.Program] = []
@@ -40,7 +40,7 @@ protocol LibraryModelDelegate: AnyObject {
     @Published var filteredPrograms: [SoftwareIndex.Program] = []
     @Published var error: Error? = nil
 
-    weak var delegate: LibraryModelDelegate?
+    weak var delegate: SoftwareIndexLibraryModelDelegate?
 
     private var cancellables: Set<AnyCancellable> = []
 

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/View Controllers/SoftwareIndexViewController.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/View Controllers/SoftwareIndexViewController.swift
@@ -21,24 +21,22 @@
 import Combine
 import SwiftUI
 
-#if os(iOS)
+public protocol SoftwareIndexViewControllerDelegate: AnyObject {
 
-public protocol PsionSoftwareIndexViewControllerDelegate: AnyObject {
-
-    func psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: PsionSoftwareIndexViewController)
-    func psionSoftwareIndexViewController(psionSoftwareIndexViewController: PsionSoftwareIndexViewController,
+    func psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: SoftwareIndexViewController)
+    func psionSoftwareIndexViewController(psionSoftwareIndexViewController: SoftwareIndexViewController,
                                           didSelectItem item: SoftwareIndexView.Item)
 
 }
 
-@MainActor public class PsionSoftwareIndexViewController: UIHostingController<SoftwareIndexView> {
+@MainActor public class SoftwareIndexViewController: UIHostingController<SoftwareIndexView> {
 
-    public weak var delegate: PsionSoftwareIndexViewControllerDelegate?
+    public weak var delegate: SoftwareIndexViewControllerDelegate?
 
-    private var libraryModel: LibraryModel
+    private var libraryModel: SoftwareIndexLibraryModel
 
     public init(filter: @escaping (SoftwareIndex.Release) -> Bool = { _ in true }) {
-        self.libraryModel = LibraryModel(filter: filter)
+        self.libraryModel = SoftwareIndexLibraryModel(filter: filter)
         super.init(rootView: SoftwareIndexView(model: libraryModel))
         libraryModel.delegate = self
     }
@@ -49,16 +47,14 @@ public protocol PsionSoftwareIndexViewControllerDelegate: AnyObject {
 
 }
 
-extension PsionSoftwareIndexViewController: LibraryModelDelegate {
+extension SoftwareIndexViewController: SoftwareIndexLibraryModelDelegate {
 
-    func libraryModelDidCancel(libraryModel: LibraryModel) {
+    func libraryModelDidCancel(libraryModel: SoftwareIndexLibraryModel) {
         delegate?.psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: self)
     }
 
-    func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item) {
+    func libraryModel(libraryModel: SoftwareIndexLibraryModel, didSelectItem item: SoftwareIndexView.Item) {
         delegate?.psionSoftwareIndexViewController(psionSoftwareIndexViewController: self, didSelectItem: item)
     }
 
 }
-
-#endif

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexIconView.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexIconView.swift
@@ -20,7 +20,7 @@
 
 import SwiftUI
 
-struct IconView: View {
+struct SoftwareIndexIconView: View {
 
     let url: URL?
 

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramRowLabel.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramRowLabel.swift
@@ -20,7 +20,7 @@
 
 import SwiftUI
 
-struct ItemView: View {
+struct SoftwareIndexProgramRowLabel: View {
 
     let imageURL: URL?
     let title: String
@@ -34,7 +34,7 @@ struct ItemView: View {
 
     var body: some View {
         HStack {
-            IconView(url: imageURL)
+            SoftwareIndexIconView(url: imageURL)
                 .padding()
             VStack(alignment: .leading) {
                 Spacer()

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramView.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramView.swift
@@ -20,9 +20,9 @@
 
 import SwiftUI
 
-struct ProgramView: View {
+struct SoftwareIndexProgramView: View {
 
-    @EnvironmentObject private var libraryModel: LibraryModel
+    @EnvironmentObject private var libraryModel: SoftwareIndexLibraryModel
 
     var program: SoftwareIndex.Program
 
@@ -63,7 +63,7 @@ struct ProgramView: View {
                     ForEach(version.variants) { variant in
                         ForEach(variant.items, id: \.uniqueId) { item in
                             HStack(alignment: .center) {
-                                IconView(url: item.iconURL)
+                                SoftwareIndexIconView(url: item.iconURL)
                                 VStack(alignment: .leading) {
                                     Text(item.name)
                                     Text(String(item.sha256.prefix(8)))

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramsView.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexProgramsView.swift
@@ -20,22 +20,21 @@
 
 import SwiftUI
 
-struct ProgramsView: View {
+struct SoftwareIndexProgramsView: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    @EnvironmentObject private var libraryModel: LibraryModel
+    @EnvironmentObject private var libraryModel: SoftwareIndexLibraryModel
 
     var body: some View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 240))], spacing: 0) {
                 ForEach(libraryModel.filteredPrograms) { program in
                     NavigationLink {
-                        ProgramView(program: program)
+                        SoftwareIndexProgramView(program: program)
                             .environmentObject(libraryModel)
                     } label: {
-                        ItemView(imageURL: program.iconURL,
-                                 title: program.name)
+                        SoftwareIndexProgramRowLabel(imageURL: program.iconURL, title: program.name)
                     }
                     .buttonStyle(.plain)
                 }

--- a/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexView.swift
+++ b/PsionSoftwareIndexSwift/Sources/PsionSoftwareIndex/Views/SoftwareIndexView.swift
@@ -20,7 +20,7 @@
 
 import SwiftUI
 
-class LibraryModelBlockDelegate: LibraryModelDelegate {
+class LibraryModelBlockDelegate: SoftwareIndexLibraryModelDelegate {
 
     let complete: (SoftwareIndexView.Item?) -> Void
 
@@ -28,17 +28,16 @@ class LibraryModelBlockDelegate: LibraryModelDelegate {
         self.complete = complete
     }
 
-    func libraryModelDidCancel(libraryModel: LibraryModel) {
+    func libraryModelDidCancel(libraryModel: SoftwareIndexLibraryModel) {
         self.complete(nil)
     }
 
-    func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item) {
+    func libraryModel(libraryModel: SoftwareIndexLibraryModel, didSelectItem item: SoftwareIndexView.Item) {
         self.complete(item)
     }
 
 }
 
-// TODO: Rename?
 public struct SoftwareIndexView: View {
 
     public struct Item {
@@ -48,11 +47,11 @@ public struct SoftwareIndexView: View {
 
     }
 
-    @StateObject var model: LibraryModel
+    @StateObject var model: SoftwareIndexLibraryModel
 
     let delegate: LibraryModelBlockDelegate?
 
-    init(model: LibraryModel) {
+    init(model: SoftwareIndexLibraryModel) {
         _model = StateObject(wrappedValue: model)
         delegate = nil
     }
@@ -60,7 +59,7 @@ public struct SoftwareIndexView: View {
     public init(filter: @escaping (SoftwareIndex.Release) -> Bool = { _ in true },
                 completion: @escaping (SoftwareIndexView.Item?) -> Void) {
         let delegate = LibraryModelBlockDelegate(complete: completion)
-        let libraryModel = LibraryModel(filter: filter)
+        let libraryModel = SoftwareIndexLibraryModel(filter: filter)
         libraryModel.delegate = delegate
         _model = StateObject(wrappedValue: libraryModel)
         self.delegate = delegate
@@ -68,7 +67,7 @@ public struct SoftwareIndexView: View {
 
     public var body: some View {
         NavigationView {
-            ProgramsView()
+            SoftwareIndexProgramsView()
                 .environmentObject(model)
         }
         .navigationViewStyle(.stack)


### PR DESCRIPTION
On-going preparatory work for moving the Software Index code into the main OpoLua project.