### PR TITLE
fix: 👆 Ensure drag gestures are passed to OPL on iOS 26

### DIFF
--- a/OpoLua/View Controllers/ProgramViewController.swift
+++ b/OpoLua/View Controllers/ProgramViewController.swift
@@ -298,6 +298,9 @@ class ProgramViewController: UIViewController {
         program.resume()
         configureControllers()
         becomeFirstResponder()
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
This entirely disables back gestures in the program view on iOS 26, but the tradeoff seems worth it.