### PR TITLE
build: Fix Qt dependency on LuaSwift

### DIFF
--- a/qt/opolua.pro
+++ b/qt/opolua.pro
@@ -58,7 +58,7 @@ SOURCES += \
     oplruntimegui.cpp \
     oplscreenwidget.cpp
 
-INCLUDEPATH += ../ios/LuaSwift/Sources/CLua/lua
+INCLUDEPATH += ../dependencies/LuaSwift/Sources/CLua/lua
 
 FORMS += \
     aboutwindow.ui \


### PR DESCRIPTION
I missed this dependency when moving the location of LuaSwift.