### PR TITLE
chore: Use HTTPS for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/jbmorley/build-tools.git
 [submodule "diligence"]
 	path = ios/diligence
-	url = git@github.com:inseven/diligence.git
+	url = https://github.com/inseven/diligence.git
 [submodule "LuaSwift"]
 	path = dependencies/LuaSwift
-	url = git@github.com:tomsci/LuaSwift.git
+	url = https://github.com/tomsci/LuaSwift.git


### PR DESCRIPTION
This change updates the diligence and LuaSwift submodules to use HTTPS by default to make it easier for new and non-authenticated developers to get started.