### PR TITLE
fix: Pass the sis file context into `sisGetStubs`

### DIFF
--- a/core/src/sis.lua
+++ b/core/src/sis.lua
@@ -650,7 +650,7 @@ function installSis(filename, data, iohandler, includeStub, verbose, stubs)
     local isRootInstall = (stubs == nil)
     if stubs == nil then
         local err
-        stubs, err = getStubs(iohandler)
+        stubs, err = getStubs(iohandler, callbackContext)
         if stubs == nil then
             return failInstall(nil, "epocerr", err)
         end
@@ -845,8 +845,8 @@ function uninstallSis(stubMap, uid, iohandler, upgrading)
     delete(sisfile.path) -- the stub
 end
 
-function getStubs(iohandler)
-    local result, err = iohandler.sisGetStubs()
+function getStubs(iohandler, callbackContext)
+    local result, err = iohandler.sisGetStubs(callbackContext)
     if result == "notimplemented" then
         result = {}
         local disks = assert(iohandler.fsop("disks", ""))

--- a/core/swift/OpoIoHandler.swift
+++ b/core/swift/OpoIoHandler.swift
@@ -810,7 +810,7 @@ public struct Sis {
 
 public protocol SisInstallIoHandler: FileSystemIoHandler {
 
-    func sisGetStubs() -> Sis.GetStubsResult
+    func sisGetStubs(sis: Sis.File) -> Sis.GetStubsResult
 
     func sisInstallBegin(sis: Sis.File, context: Sis.BeginContext) -> Sis.BeginResult
 

--- a/core/swift/PsiLuaEnv.swift
+++ b/core/swift/PsiLuaEnv.swift
@@ -505,7 +505,11 @@ public class PsiLuaEnv {
     internal static let sisGetStubs: lua_CFunction = { (L: LuaState!) -> CInt in
         let wrapper: Wrapper<SisInstallIoHandler> = L.touserdata(lua_upvalueindex(1))!
         let iohandler = wrapper.value
-        let result = iohandler.sisGetStubs()
+        guard let info: Sis.File = L.todecodable(1) else {
+            print("Bad SIS info!")
+            return 0
+        }
+        let result = iohandler.sisGetStubs(sis: info)
         switch result {
         case .stubs(let stubs):
             try! L.push(encodable: stubs)

--- a/ios/OpoLua/Model/Installer.swift
+++ b/ios/OpoLua/Model/Installer.swift
@@ -78,7 +78,7 @@ extension Installer: SisInstallIoHandler {
         return fileSystem.perform(op)
     }
 
-    func sisGetStubs() -> Sis.GetStubsResult {
+    func sisGetStubs(sis: Sis.File) -> Sis.GetStubsResult {
         return .notImplemented
     }
 


### PR DESCRIPTION
Ensures we have the SIS file context in `sisGetStubs` to allow us to make policy decisions around whether we return the existing stubs.