### PR TITLE
fix(qt): Add missing includes

### DIFF
--- a/qt/codeview.h
+++ b/qt/codeview.h
@@ -7,6 +7,7 @@
 #include <QPlainTextEdit>
 #include <QSet>
 #include <QVector>
+#include <optional>
 
 class Highlighter;
 class TokenizerBase;

--- a/qt/opldebug.h
+++ b/qt/opldebug.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QVariant>
 #include <QVector>
+#include <optional>
 
 namespace opl {
 


### PR DESCRIPTION
Only Qt 5 on linux doesn't seem to sneak optional into the system includes somewhere.

fixes #676