### PR TITLE
ci: 🔧 Use the latest version of mise, changes, and build-tools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,19 +27,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
-          fetch-depth: 0
-
-    # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-    - name: Get the latest mise version
-      id: mise
-      run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
+        fetch-depth: 0
 
     - name: Install mise
-      uses: jdx/mise-action@v4
-      with:
-        version: ${{ steps.mise.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: jbmorley/latest-mise@v1
 
     - name: Generate version and build numbers
       id: version
@@ -62,17 +53,8 @@ jobs:
       with:
         submodules: recursive
 
-    # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-    - name: Get the latest mise version
-      id: mise
-      run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
-
     - name: Install mise
-      uses: jdx/mise-action@v4
-      with:
-        version: ${{ steps.mise.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: jbmorley/latest-mise@v1
 
     - name: Build and test
       run: scripts/build-package.sh
@@ -94,17 +76,8 @@ jobs:
       with:
         submodules: recursive
 
-    # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-    - name: Get the latest mise version
-      id: mise
-      run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
-
     - name: Install mise
-      uses: jdx/mise-action@v4
-      with:
-        version: ${{ steps.mise.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: jbmorley/latest-mise@v1
 
     - name: Test Lua
       run: scripts/test.sh
@@ -305,17 +278,8 @@ jobs:
       with:
         submodules: recursive
 
-    # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-    - name: Get the latest mise version
-      id: mise
-      run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
-
     - name: Install mise
-      uses: jdx/mise-action@v4
-      with:
-        version: ${{ steps.mise.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: jbmorley/latest-mise@v1
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -367,17 +331,8 @@ jobs:
       with:
           fetch-depth: 0
 
-    # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-    - name: Get the latest mise version
-      id: mise
-      run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
-
     - name: Install mise
-      uses: jdx/mise-action@v4
-      with:
-        version: ${{ steps.mise.outputs.version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: jbmorley/latest-mise@v1
 
     - uses: actions/download-artifact@v8
       with:
@@ -422,17 +377,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Ensure we're using the latest version of mise in an attempt to catch upstream errors early.
-      - name: Get the latest mise version
-        id: mise
-        run: echo "version=$(curl -fsSL https://mise.jdx.dev/VERSION)" >> "$GITHUB_OUTPUT"
-
       - name: Install mise
-        uses: jdx/mise-action@v4
-        with:
-          version: ${{ steps.mise.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: jbmorley/latest-mise@v1
 
       - name: Cache the Jekyll dependencies
         uses: actions/cache@v6

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -106,6 +106,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/mise.toml
+++ b/mise.toml
@@ -7,3 +7,7 @@ uv = "latest"
 
 "pipx:changes-semver" = "6"
 "pipx:inseven-build-tools" = "1"
+
+[settings]
+
+minimum_release_age_excludes = ["pipx:changes-semver", "pipx:inseven-build-tools"]


### PR DESCRIPTION
This change uses `jbmorley/latest-mise` to ensure we always install the latest version of mise and update any loosely-pinned tools dependencies.
