### PR TITLE
ci: 🗓️ Reduce scheduled build frequency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,8 @@ on:
   push:
     branches: [ main ]
   schedule:
-    - cron:  '0 9 * * *'
+    # 04:00 Monday in Hawaii (HST, UTC-10, no DST) — 14:00 Monday UTC.
+    - cron: '0 14 * * 1'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This change switches from daily scheduled smoke-test builds to weekly ones to reduce our GitHub Actions usage.
